### PR TITLE
use POSTGRES_KEYCLOAK_DB for database name

### DIFF
--- a/infra/docker-compose/docker-compose-keycloak.yml
+++ b/infra/docker-compose/docker-compose-keycloak.yml
@@ -4,7 +4,7 @@ services:
     image: ${DOCKER_REPOSITORY}im-keycloak:${VERSION_IM}
     container_name: ${KC_HOSTNAME}
     environment:
-      KC_DB_URL: 'jdbc:postgresql://${POSTGRES_HOSTNAME}/im-keycloak'
+      KC_DB_URL: 'jdbc:postgresql://${POSTGRES_HOSTNAME}/${POSTGRES_KEYCLOAK_DB}'
       KC_DB_PASSWORD: ${POSTGRES_USER}
       KC_DB_USERNAME: ${POSTGRES_PASS}
       KC_DB_SCHEMA: public


### PR DESCRIPTION
Updated KC_DB_URL to reference the POSTGRES_KEYCLOAK_DB environment variable, ensuring the correct database name for Keycloak.
Improves configuration clarity and ensures proper management of database connections.
