### PR TITLE
chore(.gitignore): add env-config.js to .gitignore to prevent sensitive data exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/env-config.js
+
 .gradle
 **/build/
 !gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
The addition of **/env-config.js to the .gitignore file ensures that sensitive configuration files are not tracked by Git, reducing the risk of exposing sensitive information in version control.