### PR TITLE
3chore(Makefile_docker.mk): rename docker-keycloak-auth-publish target to docker-postgres-publish for clarity

### DIFF
--- a/Makefile_docker.mk
+++ b/Makefile_docker.mk
@@ -85,7 +85,7 @@ docker-postgres-build:
 		-f ${POSTGRES_DOCKERFILE} \
 		-t ${POSTGRES_IMG} .
 
-docker-keycloak-auth-publish:
+docker-postgres-publish:
 	@docker build --push \
 		--build-arg CI_NPM_AUTH_TOKEN=${CI_NPM_AUTH_TOKEN} \
 		--build-arg VERSION=${VERSION} \


### PR DESCRIPTION
The target name is updated to better reflect its purpose, aligning it with the associated Docker image being built and published. This change enhances the readability and maintainability of the Makefile.