### PR TITLE
Add Language Property in Tests for Multilingual Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,4 @@
 # Artifacts that will be built during image creation.
 # This should contain all files created during `npm run build`.
 build
-infra
 node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,5 @@
 # Artifacts that will be built during image creation.
 # This should contain all files created during `npm run build`.
 build
+infra
 node_modules

--- a/.env_version
+++ b/.env_version
@@ -1,0 +1,4 @@
+# Docker
+VERSION_NODE=21.7-alpine3.19
+
+VERSION_CONNECT=0.20.0

--- a/Makefile_docker.mk
+++ b/Makefile_docker.mk
@@ -1,4 +1,5 @@
 VERSION = $(shell cat VERSION)
+include .env_version
 DOCKER_REPOSITORY = ghcr.io/
 
 GATEWAY_NAME	   	:= ${DOCKER_REPOSITORY}komune-io/trace-registry-gateway
@@ -24,6 +25,9 @@ POSTGRES_NAME	    	:= trace-registry-postgres
 POSTGRES_IMG	    	:= ${POSTGRES_NAME}:${VERSION}
 POSTGRES_LATEST			:= ${POSTGRES_NAME}:latest
 
+KEYCLOAK_DOCKERFILE	    := infra/docker/keycloak/Dockerfile
+KEYCLOAK_NAME	   	 	:= trace-registry-keycloak
+KEYCLOAK_IMG	    	:= ${KEYCLOAK_NAME}:${VERSION}
 
 .PHONY: lint build test publish promote
 
@@ -98,3 +102,22 @@ docker-docker-promote:
 		--build-arg VERSION=${VERSION} \
 		-f ${POSTGRES_DOCKERFILE} \
 		-t docker.io/komune/${POSTGRES_IMG} .
+
+## keycloak
+docker-keycloak-lint:
+	@docker run --rm -i hadolint/hadolint hadolint - < ${KEYCLOAK_DOCKERFILE}
+
+docker-keycloak-build:
+	@docker build --no-cache=true \
+		--progress=plain \
+		--build-arg VERSION_CONNECT=${VERSION_CONNECT} \
+		--build-arg VERSION_NODE=${VERSION_NODE} \
+		-f ${KEYCLOAK_DOCKERFILE} -t ${KEYCLOAK_IMG} .
+
+docker-keycloak-publish:
+	@docker tag ${KEYCLOAK_IMG} ghcr.io/komune-io/${KEYCLOAK_IMG}
+	@docker push ghcr.io/komune-io/${KEYCLOAK_IMG}
+
+docker-keycloak-promote:
+	@docker tag ${KEYCLOAK_IMG} docker.io/komune/${KEYCLOAK_IMG}
+	@docker push docker.io/komune/${KEYCLOAK_IMG}

--- a/infra/docker/keycloak/Dockerfile
+++ b/infra/docker/keycloak/Dockerfile
@@ -1,0 +1,44 @@
+ARG VERSION_NODE
+ARG VERSION_CONNECT
+
+FROM node:${VERSION_NODE} as build
+
+WORKDIR /app
+
+COPY platform/web ./
+
+ARG NPM_AUTH_TOKEN
+RUN printf "\
+@komune-io:registry=https://npm.pkg.github.com\n\
+//npm.pkg.github.com/:_authToken=%s\n\
+" "${NPM_AUTH_TOKEN}" > .npmrc
+
+ARG VERSION
+ENV REACT_APP_VERSION=$VERSION
+
+RUN yarn install
+ENV PATH /app/node_modules/.bin:$PATH
+
+RUN apk add --no-cache maven=3.9.5-r0
+
+WORKDIR /app/packages/keycloak
+RUN yarn build-keycloak-theme &&\
+    unzip dist_keycloak/keycloak-theme-for-kc-22-to-25.jar -d keycloak-theme-for-kc-22-to-25
+
+FROM komune/im-keycloak:${VERSION_CONNECT}
+
+WORKDIR /app
+
+ENV KC_DB=postgres
+ENV KC_PROXY=none
+ENV KC_HTTP_ENABLED=true
+ENV KC_HOSTNAME_STRICT=false
+ENV KC_HOSTNAME=localhost
+ENV KC_HTTP_RELATIVE_PATH=/
+
+COPY --from=build  /app/packages/keycloak/keycloak-theme-for-kc-22-to-25/theme/registry-keycloakify /opt/keycloak/themes/registry-keycloakify/
+RUN /opt/keycloak/bin/kc.sh build
+
+LABEL org.opencontainers.image.source="https://github.com/komune-io/trace-registry"
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "--spi-login-protocol-openid-connect-legacy-logout-redirect-uri=true", "start"]

--- a/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/CatalogDslTestJvm.kt
+++ b/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/CatalogDslTestJvm.kt
@@ -12,6 +12,7 @@ class CatalogueDslTestJvm {
         val catalogue1: DcatApCatalogue = catalogue {
             identifier = "catalogue1"
             type = "catalogues"
+            language = "fr"
             structure = Structure("catalogues")
             title = "catalogues"
         }
@@ -23,17 +24,20 @@ class CatalogueDslTestJvm {
             identifier = "catalogue1"
             type = "catalogues"
             structure = Structure("catalogues")
+            language = "fr"
             title = "catalogues"
             datasets {
                 dataset {
                     identifier = "dataset1"
                     type = "catalogues"
                     title = "catalogues"
+                    language = "fr"
                 }
                 dataset {
                     identifier = "dataset2"
                     type = "catalogues"
                     title = "catalogues"
+                    language = "fr"
                 }
             }
         }
@@ -45,6 +49,7 @@ class CatalogueDslTestJvm {
         val catalogue1: DcatApCatalogue = catalogue {
             identifier = "catalogue1"
             type = "catalogues"
+            language = "fr"
             structure = Structure("catalogues")
             title = "catalogues"
             themes {
@@ -64,6 +69,7 @@ class CatalogueDslTestJvm {
         val catalogue1: DcatApCatalogue = catalogue {
             identifier = "catalogue1"
             type = "catalogues"
+            language = "fr"
             structure = Structure("catalogues")
             title = "catalogues"
             services {
@@ -84,18 +90,21 @@ class CatalogueDslTestJvm {
             identifier = "catalogue1"
             type = "catalogues"
             structure = Structure("catalogues")
+            language = "fr"
             title = "catalogues"
             catalogues {
                 catalogue {
                     identifier = "subCatalogue1"
                     type = "catalogues"
                     structure = Structure("catalogues")
+                    language = "fr"
                     title = "catalogues"
                 }
                 catalogue {
                     identifier = "subCatalogue2"
                     type = "catalogues"
                     structure = Structure("catalogues")
+                    language = "fr"
                     title = "catalogues"
                 }
             }
@@ -109,6 +118,7 @@ class CatalogueDslTestJvm {
             identifier = "catalogue1"
             title = "Catalogue 1"
             type = "catalogues"
+            language = "fr"
             structure = Structure("catalogues")
             catalogueRecords{
                 catalogueRecord {

--- a/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/DatasetDslTest.kt
+++ b/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/DatasetDslTest.kt
@@ -12,6 +12,7 @@ class DatasetDslTest {
             identifier = "dataset1"
             title = "catalogues"
             type = "catalogues"
+            language = "fr"
             distributions {
                 distribution {
                     identifier = "distribution1"

--- a/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/StandardsCatalogueTest.kt
+++ b/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/StandardsCatalogueTest.kt
@@ -13,6 +13,7 @@ class StandardsCatalogueTest {
             identifier = "http://example.com/catalogue1"
             type = "catalogues"
             title = "catalogues"
+            language = "fr"
             structure = Structure("catalogues")
         }
         val catalogue2: DCatApCatalogueModel = catalogue {
@@ -20,6 +21,7 @@ class StandardsCatalogueTest {
             type = "catalogues"
             title = "catalogues"
             structure = Structure("catalogues")
+            language = "fr"
             catalogues {
                 +catalogue1
             }

--- a/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/model/CatalogDslTest.kt
+++ b/platform/data/dsl/dcat/src/jvmTest/kotlin/io/komune/registry/dsl/dcat/domain/model/model/model/CatalogDslTest.kt
@@ -12,6 +12,7 @@ class CatalogueDslTest {
         val catalogue1: DCatApCatalogueModel = catalogue {
             identifier = "http://example.com/catalogue"
             type = "catalogues"
+            language = "fr"
             structure = Structure("catalogues")
             title = "catalogues"
             datasets {
@@ -19,13 +20,14 @@ class CatalogueDslTest {
                     identifier = "http://example.com/datasets/weather"
                     type = "catalogues"
                     title = "catalogues"
+                    language = "fr"
 
                 }
                 dataset {
                     identifier = "http://example.com/datasets/weather1"
                     type = "catalogues"
                     title = "catalogues"
-
+                    language = "fr"
                 }
             }
         }

--- a/platform/web/packages/keycloak/package.json
+++ b/platform/web/packages/keycloak/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "regisry-keycloakify",
+    "name": "registry-keycloakify",
     "version": "0.0.0",
     "description": "Regisry Keycloakify Theme",
     "type": "module",

--- a/platform/web/packages/keycloak/package.json
+++ b/platform/web/packages/keycloak/package.json
@@ -1,11 +1,7 @@
 {
-    "name": "keycloakify-starter",
+    "name": "regisry-keycloakify",
     "version": "0.0.0",
-    "description": "Starter for Keycloakify 11",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/codegouvfr/keycloakify-starter.git"
-    },
+    "description": "Regisry Keycloakify Theme",
     "type": "module",
     "scripts": {
         "start": "vite",

--- a/platform/web/packages/web-app/src/App/pages/Catalogue/CataloguesRouter/CataloguesRouter.tsx
+++ b/platform/web/packages/web-app/src/App/pages/Catalogue/CataloguesRouter/CataloguesRouter.tsx
@@ -13,7 +13,7 @@ export const CataloguesRouter = (props: CataloguesRouterProps) => {
     const catalogueId = ids[ids.length - 1] ??  root
     const catalogueGet = useCatalogueGetQuery({
         query: {
-            identifier: catalogueId!
+            id: catalogueId!
         }
     })
     return catalogueGet.data?.item?.structure?.type === "item" ? (

--- a/platform/web/yarn.lock
+++ b/platform/web/yarn.lock
@@ -3525,7 +3525,7 @@ abbrev@1:
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-acorn-jsx@^5.0.0:
+acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -7203,6 +7203,14 @@ next-tick@^1.1.0:
   resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
+
 node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
@@ -9102,6 +9110,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.2.3:
+  version "8.18.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
- Removed infra from `.dockerignore` to include infrastructure files in the Docker image for proper containerization.
- Introduced Keycloak Docker support, added configuration, and corrected spelling of "registry" in the Keycloak package name.
- Renamed package from `keycloakify-starter` to `registry-keycloakify` and updated description; also, changed query identifier key in `CataloguesRouter` for consistency.
- Added `language` property to catalogues and datasets in tests to support multilingual capabilities for internationalization.





