### PR TITLE
fix(index.html): remove versioning from env-config.js script source

### DIFF
--- a/platform/web/packages/keycloak/index.html
+++ b/platform/web/packages/keycloak/index.html
@@ -6,7 +6,7 @@
 
         <link rel="icon" type="image/x-icon" sizes="64x64" href="/logo.ico" />
         <link rel="stylesheet" href="/custom.css" type="text/css"/>
-        <script src="/env-config.js?v=%VITE_APP_VERSION%"></script>
+        <script src="/env-config.js"></script>
     </head>
 
     <body>


### PR DESCRIPTION
The versioning query parameter is removed from the script source to simplify the loading of the env-config.js file. This change ensures that the script is always loaded without versioning, which can help avoid caching issues during development.