### PR TITLE
fix(command.ts): update userOnboard command path to include identity prefix for correct API routing

### DIFF
--- a/platform/web/packages/keycloak/src/login/api/command.ts
+++ b/platform/web/packages/keycloak/src/login/api/command.ts
@@ -8,5 +8,5 @@ export const useUserOnboardCommand  = (
     params?: CommandParams<UserOnboardCommand, UserOnboardedEvent>
 ) => {
     const requestProps = useNoAuthenticatedRequest()
-    return useCommandRequest('userOnboard ', requestProps, params)
+    return useCommandRequest('identity/userOnboard ', requestProps, params)
 }


### PR DESCRIPTION
The command path for user onboarding is modified to include the 'identity/' prefix, ensuring that the API request is routed correctly to the intended endpoint. This change resolves potential issues with API calls not reaching the correct service.