### PR TITLE
feat(router.tsx): replace ProjectList with CataloguesRouter as the default route element

### DIFF
--- a/platform/web/packages/web-app/src/App/pages/router.tsx
+++ b/platform/web/packages/web-app/src/App/pages/router.tsx
@@ -3,11 +3,12 @@ import {ProjectList, ProjectView} from "./Project";
 import {TransactionView} from "./Transaction/TransactionView/TransactionView";
 import {TransactionList} from "./Transaction/TransactionList/TransactionList";
 import { ProjectCreate } from "./Project/ProjectCreate/ProjectCreate";
+import {CataloguesRouter} from "./Catalogue/CataloguesRouter/CataloguesRouter";
 
 export const registryPages: PageRoute[] = [
   {
     path: "",
-    element: <ProjectList />
+    element: <CataloguesRouter root="catalogues" />
   },
   {
     path: "projects",


### PR DESCRIPTION
The default route now renders the CataloguesRouter instead of the ProjectList. This change is made to prioritize the catalogues feature in the application, enhancing user navigation and experience by directing users to the catalogues section upon accessing the root path.