### PR TITLE
fix(Register.tsx): rename checkbox field from acceptChart100M to acceptNewsletter for clarity

### DIFF
--- a/platform/web/packages/keycloak/src/login/Pages/Register.tsx
+++ b/platform/web/packages/keycloak/src/login/Pages/Register.tsx
@@ -101,7 +101,7 @@ export const Register = (props: PageProps<Extract<KcContext, { pageId: "register
             </>,
             required: true
         }, {
-            name: "acceptChart100M",
+            name: "acceptNewsletter",
             type: "checkBox",
             //@ts-ignore
             label: msgStr("wantNewsletter"),


### PR DESCRIPTION
The checkbox field is renamed to better reflect its purpose, which is to allow users to opt-in for a newsletter. This change enhances the user experience by providing clearer options during the registration process.