### PR TITLE
fix(ImportScript.kt): update path for matchedPathToActualPath to reflect correct dataset operation

### DIFF
--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportScript.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportScript.kt
@@ -298,7 +298,7 @@ class ImportScript(
                     mediaType = Files.probeContentType(resourceFile.toPath()) ?: "application/octet-stream",
                     file = resourceFile.toSimpleFile()
                 )
-                matchedPathToActualPath[path] = "/data/datasetAddMediaDistribution/$resourcesDatasetId/$distributionId"
+                matchedPathToActualPath[path] = "/data/datasetDownloadDistribution/$resourcesDatasetId/$distributionId"
             }
 
             modifiedText = modifiedText.replace(imageMatch.value, "![$alt](${matchedPathToActualPath[path]} $title)")

--- a/platform/web/packages/domain/src/Catalogue/components/CatalogueResultList/CatalogueResultList.tsx
+++ b/platform/web/packages/domain/src/Catalogue/components/CatalogueResultList/CatalogueResultList.tsx
@@ -15,9 +15,7 @@ export const CatalogueResultList = (props: CatalogueResultListProps) => {
     const { catalogues, groupLabel } = props
 
     const display = useMemo(() => catalogues?.map((catalogue, index) => (
-        <Fragment
-        key={catalogue.id}
-        >
+        <Fragment key={catalogue.id}>
             <CatalogueResult {...catalogue} />
             {index < catalogues.length - 1 && <Divider />}
         </Fragment>
@@ -43,7 +41,7 @@ export const CatalogueResultList = (props: CatalogueResultListProps) => {
 }
 
 const CatalogueResult = (props: Catalogue) => {
-    const { title, themes, id } = props
+    const { title, themes, id, identifier } = props
 
     const {cataloguesAll} = useRoutesDefinition()
 
@@ -57,7 +55,7 @@ const CatalogueResult = (props: Catalogue) => {
             alignItems="center"
             gap={3}
             component={Link}
-            to={cataloguesAll(id)}
+            to={cataloguesAll(identifier)}
             sx={{
                 textDecoration: "none"
             }}


### PR DESCRIPTION
The path for matchedPathToActualPath is changed from datasetAddMediaDistribution to datasetDownloadDistribution to accurately represent the operation being performed. This ensures that the application correctly references the intended dataset download functionality.