### PR TITLE
docs(manual-deploy.yml): update descriptions and types for clarity in…

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -10,10 +10,10 @@ on:
         default: 'dev'
         type: string
       run_reset:
-        description: 'Set to true to perform a reset before deployment (for non-prod)'
+        description: 'Set to "true" to perform a reset before deployment (for non-prod)'
         required: false
-        default: 'false'
-        type: boolean
+        default: "false"
+        type: string
 
 jobs:
   deploy:


### PR DESCRIPTION
… workflow inputs

The description for the `run_reset` input is modified to clarify that the value should be a string "true" for performing a reset. Additionally, the type for `run_reset` is changed from boolean to string to align with the expected input format, enhancing the documentation and usability of the workflow.