### PR TITLE
chore(manual-deploy.yml): change run_reset parameter from string to b…

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -11,9 +11,8 @@ on:
         type: string
       run_reset:
         description: 'Set to "true" to perform a reset before deployment (for non-prod)'
-        required: false
-        default: "false"
-        type: string
+        required: true
+        type: boolean
 
 jobs:
   deploy:


### PR DESCRIPTION
…oolean and make it required

The run_reset parameter is now a boolean and required, which simplifies the input handling and ensures that the deployment process is more explicit about whether a reset should occur. This change enhances clarity and reduces potential errors during deployment.