### PR TITLE
fix(deploy.yml): change type of run_reset input from boolean to string for compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,8 @@ on:
       run_reset:
         description: 'Set to true to perform a reset (stack removal) before deployment. (Non-prod only)'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
 
 jobs:
   create_env:


### PR DESCRIPTION
The input type for run_reset is changed to string to ensure compatibility with the GitHub Actions input handling, as it allows for better flexibility in parsing and managing input values. This change prevents potential issues with type mismatches during workflow execution.