### PR TITLE
chore(deploy.yml): add SSH key setup step for GitHub Actions to enable secure access to Docker context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,14 @@ jobs:
             exit 0
           fi
 
+      - name: Add SSH key
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DOCKER_CONTEXT_SSH_KEY }}" > ~/.ssh/github_actions
+          chmod 600 ~/.ssh/github_actions
+          ssh-add ~/.ssh/github_actions
       - name: Ensure Docker Context Exists (Reset)
         shell: bash
         env:


### PR DESCRIPTION
The addition of the SSH key setup step allows the GitHub Actions workflow to securely access the Docker context. This is necessary for operations that require authentication, ensuring that the deployment process can interact with private repositories or services without exposing sensitive information.