### PR TITLE
chore(deploy.yml): remove unnecessary SSH_AUTH_SOCK environment variable from the workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,6 @@ jobs:
           fi
 
       - name: Add SSH key
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DOCKER_CONTEXT_SSH_KEY }}" > ~/.ssh/github_actions


### PR DESCRIPTION
The SSH_AUTH_SOCK environment variable is no longer needed for the SSH key addition step, simplifying the workflow configuration. This change reduces potential confusion and streamlines the deployment process.