### PR TITLE
chore(deploy.yml): remove unnecessary ssh-add command from the workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DOCKER_CONTEXT_SSH_KEY }}" > ~/.ssh/github_actions
           chmod 600 ~/.ssh/github_actions
-          ssh-add ~/.ssh/github_actions
+
       - name: Ensure Docker Context Exists (Reset)
         shell: bash
         env:


### PR DESCRIPTION
The ssh-add command is removed as it is not needed for the current workflow. This simplifies the deployment process and reduces potential errors related to SSH key management.