### PR TITLE
chore(deploy.yml): update SSH key storage directory for GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,10 +45,10 @@ jobs:
 
       - name: Add SSH key
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DOCKER_CONTEXT_SSH_KEY }}" > ~/.ssh/github_actions
-          chmod 600 ~/.ssh/github_actions
-
+          mkdir -p ~/.ssh_100m
+          echo "${{ secrets.DOCKER_CONTEXT_SSH_KEY }}" > ~/.ssh_100m/github_actions
+          chmod 600 ~/.ssh_100m/github_actions
+          ssh-add ~/.ssh_100m/github_actions
       - name: Ensure Docker Context Exists (Reset)
         shell: bash
         env:


### PR DESCRIPTION
The SSH key is now stored in a dedicated directory `~/.ssh_100m` instead of the default `~/.ssh`. This change helps to avoid potential conflicts with other SSH configurations and improves organization within the GitHub Actions environment. Additionally, the SSH key is added to the SSH agent for better management during the deployment process.