### PR TITLE
chore(deploy.yml): add ssh-agent initialization to the deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
           mkdir -p ~/.ssh_100m
           echo "${{ secrets.DOCKER_CONTEXT_SSH_KEY }}" > ~/.ssh_100m/github_actions
           chmod 600 ~/.ssh_100m/github_actions
+          eval "$(ssh-agent -s)"
           ssh-add ~/.ssh_100m/github_actions
       - name: Ensure Docker Context Exists (Reset)
         shell: bash


### PR DESCRIPTION
The addition of `eval "$(ssh-agent -s)"` initializes the SSH agent, which is necessary for managing SSH keys during the deployment process. This ensures that the SSH key can be added successfully, allowing for secure connections to remote servers.