### PR TITLE
chore(deploy.yml): remove unnecessary secrets declaration from the workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ on:
 jobs:
   create_env:
     runs-on: ubuntu-latest
-    secrets:
-        DOCKER_CONTEXT_SSH_KEY: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
The secrets declaration for DOCKER_CONTEXT_SSH_KEY is removed as it is not being used in the workflow. This cleanup helps to maintain a clearer and more concise configuration file.