### PR TITLE
chore(workflows): add required secret for DOCKER_CONTEXT_SSH_KEY in d…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: "false"
         type: string
+    secrets:
+      DOCKER_CONTEXT_SSH_KEY:
+        required: true
 
 jobs:
   create_env:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     name: Deploy to ${{ github.event.inputs.environment }}
     uses: ./.github/workflows/deploy.yml
     secrets:
-        DOCKER_CONTEXT_SSH_KEY: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
+      DOCKER_CONTEXT_SSH_KEY: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
     with:
       environment: ${{ github.event.inputs.environment }}
       run_reset: ${{ github.event.inputs.run_reset }}


### PR DESCRIPTION
…eploy workflows

The DOCKER_CONTEXT_SSH_KEY secret is now marked as required in the deploy workflows to ensure that the necessary SSH key is always provided for secure Docker context operations. This change enhances security and prevents potential deployment failures due to missing credentials.