### PR TITLE
chore(workflows): consolidate deployment jobs and remove redundant configurations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ on:
         required: true
 
 jobs:
-  create_env:
+  deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
@@ -29,7 +29,6 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
-
       - name: Ensure Docker Context Exists
         shell: bash
         env:
@@ -39,16 +38,24 @@ jobs:
           if ! docker context ls -q | grep -w "100m_${{ inputs.environment }}" ; then
             docker context create 100m_${{ inputs.environment }} --docker "${{ secrets.DOCKER_CONTEXT }}"
           fi
-
       - name: Create Environment File
         shell: bash
         run: |
           echo "Creating environment file for ${{ inputs.environment }}..."
           cp infra/docker-compose/.env_dev_default infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
+      - name: Deploy Docker Services (Prod)
+        shell: bash
+        run: |
+          echo "Deploying Docker services to Prod environment..."
+          docker context use 100m_${{ inputs.environment }}
+          make proxy deploy
+          make connect deploy
+          make connect-init deploy
+          make registry deploy
+
 
   reset:
     if: ${{ inputs.environment == 'dev' || inputs.environment == 'preprod' }}
-    needs: create_env
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
@@ -62,9 +69,6 @@ jobs:
             echo "Reset not enabled. Skipping reset step."
             exit 0
           fi
-
-    
-
       - name: Reset Docker Stack
         shell: bash
         run: |
@@ -72,42 +76,3 @@ jobs:
           docker context use 100m_${{ inputs.environment }}
           docker stack rm registry-${{ inputs.environment }}-network || true
           docker volume rm registry-${{ inputs.environment }}-network_meilisearch_data registry-${{ inputs.environment }}-network_minio registry-${{ inputs.environment }}-network_postgres_data || true
-
-  deploy_nonprod:
-    if: ${{ inputs.environment == 'dev' || inputs.environment == 'preprod' }}
-    needs: [create_env, reset]
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Deploy Docker Services (Dev/Preprod)
-        shell: bash
-        run: |
-          echo "Deploying Docker services to ${{ inputs.environment }} environment..."
-          docker context use 100m_${{ inputs.environment }}
-          # Make scripts auto-detect the correct .env file
-          make proxy deploy
-          make connect deploy
-          make connect-init deploy
-          make registry deploy
-
-  deploy_prod:
-    if: ${{ inputs.environment == 'prod' }}
-    needs: create_env
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Deploy Docker Services (Prod)
-        shell: bash
-        run: |
-          echo "Deploying Docker services to Prod environment..."
-          docker context use 100m_${{ inputs.environment }}
-          make proxy deploy
-          make connect deploy
-          make connect-init deploy
-          make registry deploy

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -139,13 +139,12 @@ jobs:
       DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
       DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
 
-  deploy_dev:
-    name: Deploy to Dev
-    if: github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/deploy.yml
-    with:
-      environment: dev
-
+#  deploy_dev:
+#    name: Deploy to Dev
+#    if: github.ref == 'refs/heads/main'
+#    uses: ./.github/workflows/deploy.yml
+#    with:
+#      environment: dev
 #  deploy_preprod:
 #    name: Deploy to Preprod
 #    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
The deployment jobs are streamlined by merging the create_env and deploy jobs into a single deploy job. This reduces redundancy and simplifies the workflow configuration. The non-production deployment job is removed to avoid unnecessary complexity, while the environment variable handling is improved for better clarity and maintainability.