### PR TITLE
chore(deploy.yml): rename debug step to reflect its purpose and add k…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,11 +41,13 @@ jobs:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
-      - name: Debug SSH Agent
+      - name: Add remote host to known_hosts
         shell: bash
+        env:
+          SERVER_IP: ${{ env.SERVER_IP }}
         run: |
-          echo "SSH_AUTH_SOCK: $SSH_AUTH_SOCK"
-          ssh-add -l
+          mkdir -p ~/.ssh
+          ssh-keyscan -p 2234 51.15.204.133 >> ~/.ssh/known_hosts
 
       - name: Ensure Docker Context Exists
         shell: bash


### PR DESCRIPTION
…nown_hosts entry for SSH

The step is renamed to "Add remote host to known_hosts" to clarify its function. Additionally, it now includes a command to add the remote server's SSH key to the known_hosts file, which enhances security by preventing man-in-the-middle attacks during SSH connections.