### PR TITLE
feat(workflows): add HOST_NAME_REGISTRY as a required secret for deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,8 @@ on:
         required: true
       SECRET_MEILI_MASTER_KEY:
         required: true
+      HOST_NAME_REGISTRY:
+        required: true
 
 jobs:
   deploy:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -35,6 +35,7 @@ jobs:
       SECRET_KC_ADMIN_PASS: ${{ secrets.SECRET_KC_ADMIN_PASS }}
       SECRET_TRAEFIK_DASHBOARD_PASSWORD: ${{ secrets.SECRET_TRAEFIK_DASHBOARD_PASSWORD }}
       SECRET_MEILI_MASTER_KEY: ${{ secrets.SECRET_MEILI_MASTER_KEY }}
+      HOST_NAME_REGISTRY: ${{ secrets.HOST_NAME_REGISTRY }}
     with:
       environment: ${{ github.event.inputs.environment }}
       run_reset: ${{ github.event.inputs.run_reset }}


### PR DESCRIPTION
The HOST_NAME_REGISTRY secret is now required in both deploy and manual-deploy workflows to ensure that the necessary hostname configuration is available during deployment. This change enhances the deployment process by making it more robust and configurable.