### PR TITLE
chore(deploy): update HOST_NAME_REGISTRY secret reference in workflow…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
       SECRET_KC_ADMIN_PASS: ${{ secrets.SECRET_KC_ADMIN_PASS }}
       SECRET_TRAEFIK_DASHBOARD_PASSWORD: ${{ secrets.SECRET_TRAEFIK_DASHBOARD_PASSWORD }}
       SECRET_MEILI_MASTER_KEY: ${{ secrets.SECRET_MEILI_MASTER_KEY }}
+      HOST_NAME_REGISTRY: ${{ secrets.HOST_NAME_REGISTRY }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       SECRET_KC_ADMIN_PASS: ${{ secrets.SECRET_KC_ADMIN_PASS }}
       SECRET_TRAEFIK_DASHBOARD_PASSWORD: ${{ secrets.SECRET_TRAEFIK_DASHBOARD_PASSWORD }}
       SECRET_MEILI_MASTER_KEY: ${{ secrets.SECRET_MEILI_MASTER_KEY }}
-      HOST_NAME_REGISTRY: ${{ secrets.HOST_NAME_REGISTRY }}
+      HOST_NAME_REGISTRY: ${{ env.HOST_NAME_REGISTRY }}
     with:
       environment: ${{ github.event.inputs.environment }}
       run_reset: ${{ github.event.inputs.run_reset }}


### PR DESCRIPTION
…s for consistency

The HOST_NAME_REGISTRY secret is now referenced consistently across both workflow files. In the manual-deploy.yml file, it is updated to use `${{ env.HOST_NAME_REGISTRY }}` to align with the environment variable approach, ensuring better maintainability and clarity in the deployment process.