### PR TITLE
chore(deploy.yml): remove HOST_NAME_REGISTRY requirement from deploym…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,6 @@ on:
         required: true
       SECRET_MEILI_MASTER_KEY:
         required: true
-      HOST_NAME_REGISTRY:
-        required: true
 
 jobs:
   deploy:


### PR DESCRIPTION
…ent workflow

The HOST_NAME_REGISTRY environment variable is no longer necessary for the deployment process, simplifying the workflow configuration and reducing the complexity for users.