### PR TITLE
chore(deploy.yml): update environment file creation process to use cp…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,8 @@ jobs:
         shell: bash
         run: |
           echo "Creating environment file for ${{ inputs.environment }}..."
-          envsubst < infra/docker-compose/.env_dev_default > infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
+          cp infra/docker-compose/.env_dev_default infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
+          sed -i '' 's|HOST_NAME_REGISTRY=\${HOST_NAME_REGISTRY}|HOST_NAME_REGISTRY=tt.com|g' infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
           cat infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
       - name: Deploy Docker Services (Prod)
         shell: bash


### PR DESCRIPTION
… and sed for better clarity and efficiency

The environment file creation process is modified to use `cp` for copying the default environment file and `sed` for replacing the registry host name. This change enhances clarity and efficiency by explicitly defining the steps involved in creating the environment file for deployment.