### PR TITLE
fix(deploy.yml): update HOST_NAME_REGISTRY substitution to use variab…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,8 @@ jobs:
         run: |
           echo "Creating environment file for ${{ inputs.environment }}..."
           cp infra/docker-compose/.env_dev_default infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
-          sed -i '' 's|HOST_NAME_REGISTRY=\${HOST_NAME_REGISTRY}|HOST_NAME_REGISTRY=tt.com|g' infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
+          ls infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
+          sed -i '' 's|HOST_NAME_REGISTRY=\${HOST_NAME_REGISTRY}|HOST_NAME_REGISTRY=${{ vars.HOST_NAME_REGISTRY }}|g' infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
           cat infra/docker-compose/.env_dev_100m_${{ inputs.environment }}
       - name: Deploy Docker Services (Prod)
         shell: bash


### PR DESCRIPTION
…le from GitHub Actions

The substitution for HOST_NAME_REGISTRY now uses the variable from GitHub Actions instead of a hardcoded value. This change enhances the flexibility of the deployment process by allowing the use of different registry hostnames based on the environment, making it easier to manage deployments across various environments.