### PR TITLE
chore(Makefile_deploy.mk): update docker-compose include path to use …

### DIFF
--- a/Makefile_deploy.mk
+++ b/Makefile_deploy.mk
@@ -1,2 +1,2 @@
 ## DOCKER-COMPOSE DEV ENVIRONMENT
-include infra/docker-compose-stack/dev-compose.mk
+include infra/docker-compose-deploy/dev-compose.mk


### PR DESCRIPTION
…deploy environment

The include path for the docker-compose file is changed to point to the deploy environment. This ensures that the correct configuration is used for deployment, aligning the Makefile with the intended deployment setup.