### PR TITLE
chore(docker-compose): remove container_name entries for consistency …

### DIFF
--- a/infra/docker-compose-deploy/docker-compose-cccev.yml
+++ b/infra/docker-compose-deploy/docker-compose-cccev.yml
@@ -2,7 +2,6 @@ services:
 
   cccev-gateway:
     image: ${DOCKER_REPOSITORY}cccev-gateway:${CONNECT_CCCEV_VERSION}
-    container_name: cccev-gateway
     env_file:
       - build/config/.env_dev
     environment:
@@ -26,7 +25,6 @@ services:
 
   neo4j:
     image: neo4j:5.5.0
-    container_name: cccev-neo4j
     environment:
       - NEO4J_AUTH=neo4j/komunekomune
       - NEO4J_PLUGINS=["apoc"]

--- a/infra/docker-compose-deploy/docker-compose-connect-admin.yml
+++ b/infra/docker-compose-deploy/docker-compose-connect-admin.yml
@@ -1,7 +1,6 @@
 services:
   connect-admin-web:
     image: ${DOCKER_REPOSITORY}connect-admin-web:${VERSION_CONNECT_ADMIN}
-    container_name: connect-admin-web
     env_file:
       - .env_dev
     labels:

--- a/infra/docker-compose-deploy/docker-compose-fake-smtp.yml
+++ b/infra/docker-compose-deploy/docker-compose-fake-smtp.yml
@@ -1,6 +1,5 @@
 services:
   connect-fake-smtp:
-    container_name: ${SMTP_HOST}
     image: reachfive/fake-smtp-server:latest
     labels:
       traefik.enable: "true"

--- a/infra/docker-compose-deploy/docker-compose-fs.yml
+++ b/infra/docker-compose-deploy/docker-compose-fs.yml
@@ -1,7 +1,6 @@
 services:
 
   fs-gateway:
-    container_name: fs-gateway
     image: ${DOCKER_REPOSITORY}fs-gateway:${CONNECT_FS_VERSION}
     env_file:
       - .env_dev

--- a/infra/docker-compose-deploy/docker-compose-im-config.yml
+++ b/infra/docker-compose-deploy/docker-compose-im-config.yml
@@ -2,7 +2,6 @@ services:
 
   im-config:
     image: ${DOCKER_REPOSITORY}im-script:${VERSION_IM}
-    container_name: im-config
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-im-init.yml
+++ b/infra/docker-compose-deploy/docker-compose-im-init.yml
@@ -2,7 +2,6 @@ services:
 
   im-init:
     image: ${DOCKER_REPOSITORY}im-script:${VERSION_IM}
-    container_name: im-init
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-im.yml
+++ b/infra/docker-compose-deploy/docker-compose-im.yml
@@ -2,7 +2,6 @@ services:
 
   im-gateway:
     image: ${DOCKER_REPOSITORY}im-gateway:${VERSION_IM}
-    container_name: registry-im
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-keycloak.yml
+++ b/infra/docker-compose-deploy/docker-compose-keycloak.yml
@@ -2,7 +2,6 @@ services:
 
   im-keycloak:
     image: ${DOCKER_REGISTRY_REPOSITORY}trace-registry-keycloak:${REGISTRY_VERSION}
-    container_name: ${KC_HOST_NAME}
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-meilisearch.yml
+++ b/infra/docker-compose-deploy/docker-compose-meilisearch.yml
@@ -1,7 +1,6 @@
 services:
   meilisearch:
     image: getmeili/meilisearch:latest
-    container_name: meilisearch
     environment:
       MEILI_MASTER_KEY: ${SECRET_MEILI_MASTER_KEY}
     volumes:

--- a/infra/docker-compose-deploy/docker-compose-minio.yml
+++ b/infra/docker-compose-deploy/docker-compose-minio.yml
@@ -1,7 +1,6 @@
 services:
   minio:
     image: minio/minio:RELEASE.2022-02-26T02-54-46Z.fips
-    container_name: minio
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-postgres.yml
+++ b/infra/docker-compose-deploy/docker-compose-postgres.yml
@@ -1,7 +1,6 @@
 services:
   tr-registry-postgres:
     image: ${DOCKER_REPOSITORY}trace-registry-postgres:1.3.0-SNAPSHOT
-    container_name: ${POSTGRES_HOSTNAME}
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-redis.yml
+++ b/infra/docker-compose-deploy/docker-compose-redis.yml
@@ -2,7 +2,6 @@ services:
 
   redis:
     image: redis/redis-stack:7.2.0-v13
-    container_name: verr-redis
     env_file:
       - .env_dev
     environment:

--- a/infra/docker-compose-deploy/docker-compose-registry-gateway.yml
+++ b/infra/docker-compose-deploy/docker-compose-registry-gateway.yml
@@ -1,7 +1,6 @@
 services:
   registry-gateway:
     image: ${DOCKER_REGISTRY_REPOSITORY}trace-registry-gateway:${REGISTRY_VERSION}
-    container_name: registry-gateway
     environment:
       - spring_r2dbc_url=r2dbc:postgresql://${POSTGRES_HOSTNAME}:5432/${POSTGRES_REGISTRY_DB}
       - spring_r2dbc_username=${POSTGRES_USER}

--- a/infra/docker-compose-deploy/docker-compose-registry-init.yml
+++ b/infra/docker-compose-deploy/docker-compose-registry-init.yml
@@ -1,7 +1,6 @@
 services:
 
   tr-registry-script:
-    container_name: tr-registry-script
     image: ${DOCKER_REGISTRY_REPOSITORY}trace-registry-script:${REGISTRY_VERSION}
     env_file:
       - .env_dev

--- a/infra/docker-compose-deploy/docker-compose-registry-web.yml
+++ b/infra/docker-compose-deploy/docker-compose-registry-web.yml
@@ -1,7 +1,6 @@
 services:
   registry-web:
     image: ${DOCKER_REGISTRY_REPOSITORY}trace-registry-web:${REGISTRY_VERSION}
-    container_name: registry-web
     configs:
       - source: registry_web_env_config
         target: /var/www/env-config.js


### PR DESCRIPTION
…across docker-compose files

Add a new .env_dev file for environment variable management in development. The removal of container_name entries standardizes the configuration across all docker-compose files, making it easier to manage and deploy services without hardcoded container names. The addition of the .env_dev file allows for better management of environment variables, improving the flexibility and configurability of the deployment setup.