### PR TITLE
feat(oidc): add OidcTrustedDomains configuration for connect-admin an…

### DIFF
--- a/infra/docker-compose-deploy/config/connect-admin/OidcTrustedDomains.js
+++ b/infra/docker-compose-deploy/config/connect-admin/OidcTrustedDomains.js
@@ -1,0 +1,15 @@
+// Domains used by OIDC server must be also declared here
+const trustedDomains = {
+    default: {
+        oidcDomains: ["${PUBLIC_URL_KC}"],
+        accessTokenDomains: [
+            "${HOST_NAME_CONNECT}",
+            "${PUBLIC_URL_KC}"
+        ],
+    },
+};
+
+trustedDomains.config_multi_tab_login = {
+    domains: ["${PUBLIC_URL_REGISTRY}", "${PUBLIC_URL_KC}"],
+    allowMultiTabLogin: true,
+};

--- a/infra/docker-compose-deploy/config/registry/OidcTrustedDomains.js
+++ b/infra/docker-compose-deploy/config/registry/OidcTrustedDomains.js
@@ -1,0 +1,15 @@
+// Domains used by OIDC server must be also declared here
+const trustedDomains = {
+    default: {
+        oidcDomains: ["${PUBLIC_URL_KC}"],
+        accessTokenDomains: [
+            "${PUBLIC_URL_REGISTRY_API}",
+            "${PUBLIC_URL_KC}"
+        ],
+    },
+};
+
+trustedDomains.config_multi_tab_login = {
+    domains: ["${PUBLIC_URL_REGISTRY}", "${PUBLIC_URL_KC}"],
+    allowMultiTabLogin: true,
+};


### PR DESCRIPTION
…d registry

The new OidcTrustedDomains.js files define trusted domains for the OIDC server in both the connect-admin and registry configurations. This allows for proper domain management and enhances security by ensuring that only specified domains can interact with the OIDC server.