### PR TITLE
chore(.gitignore): restrict ignored files to the platform directory f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-**/env-config.js
-**/OidcTrustedDomains.js
+platform/**/env-config.js
+platform/**/OidcTrustedDomains.js
 
 .gradle
 **/build/

--- a/infra/docker-compose-deploy/config/space-create.json
+++ b/infra/docker-compose-deploy/config/space-create.json
@@ -2,6 +2,7 @@
     "space": "${KC_REALM}",
     "theme": "${KC_REALM_THEME}",
     "locales": ["en", "fr", "es"],
+    "mfa": ["OTP"],
     "settings": {
         "login": {
             "registrationAllowed": true,


### PR DESCRIPTION
…or better specificity

feat(space-create.json): add multi-factor authentication (MFA) support with OTP The .gitignore file now specifies that env-config.js and OidcTrustedDomains.js should only be ignored within the platform directory, improving clarity and preventing accidental exposure of sensitive files. The space-create.json file is updated to include MFA support, enhancing security by allowing one-time password (OTP) authentication.