### PR TITLE
feat(docker-compose-fs.yml): add MinIO credentials to the Docker Comp…

### DIFF
--- a/infra/docker-compose-deploy/docker-compose-fs.yml
+++ b/infra/docker-compose-deploy/docker-compose-fs.yml
@@ -8,6 +8,8 @@ services:
       - f2_tenant_issuer-base-uri=${PUBLIC_URL_KC}
       - fs_s3_internal-url=http://minio:9000
       - fs_s3_external-url=http://localhost:9000
+      - fs_s3_username=${MINIO_ROOT_USERNAME}
+      - fs_s3_password=${MINIO_ROOT_PASSWORD}
       - fs_s3_bucket=registry-local
       - fs_init_buckets=registry-local
 #      - fs_kb_url=${KB_HOST_NAME}


### PR DESCRIPTION
…ose configuration for S3 integration

The addition of fs_s3_username and fs_s3_password allows the application to authenticate with MinIO, ensuring secure access to the S3 storage service. This change is necessary for proper integration and functionality of the application with the MinIO service.