### PR TITLE
chore(workflows): update workflow names for clarity and consistency

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: Manual Deployment
+name: Deployment Manual
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,4 +1,4 @@
-name: Release Workflow
+name: Deployment Release
 on:
   release:
     types: [published]
@@ -47,4 +47,4 @@ jobs:
       SECRET_TRAEFIK_DASHBOARD_PASSWORD: ${{ secrets.SECRET_TRAEFIK_DASHBOARD_PASSWORD }}
       SECRET_MEILI_MASTER_KEY: ${{ secrets.SECRET_MEILI_MASTER_KEY }}
     with:
-      environment: rod
+      environment: prod


### PR DESCRIPTION
The names of the workflows have been changed to better reflect their purpose. "Manual Deployment" is now "Deployment Manual" and "Release Workflow" is now "Deployment Release." Additionally, the environment for the release workflow has been updated from "rod" to "prod" to align with standard production naming conventions. These changes enhance clarity and maintain consistency across the workflow files.