### PR TITLE
chore(workflows): specify the main branch for deploy-workflow.yml usage in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   deploy-dev:
     name: Deploy to ${{ github.event.inputs.environment }}
-    uses: ./.github/workflows/deploy-workflow.yml
+    uses: ./.github/workflows/deploy-workflow.yml@main
     secrets:
       DOCKER_CONTEXT_SSH_KEY: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
       DOCKER_CONTEXT: ${{ secrets.DOCKER_CONTEXT }}

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   deploy-preprod:
     name: Deploy to ${{ github.event.inputs.environment }}
-    uses: ./.github/workflows/deploy-workflow.yml
+    uses: ./.github/workflows/deploy-workflow.yml@main
     secrets:
       DOCKER_CONTEXT_SSH_KEY: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
       DOCKER_CONTEXT: ${{ secrets.DOCKER_CONTEXT }}
@@ -28,7 +28,7 @@ jobs:
 
   deploy-prod:
     needs: deploy-preprod
-    uses: ./.github/workflows/deploy-workflow.yml
+    uses: ./.github/workflows/deploy-workflow.yml@main
     secrets:
       DOCKER_CONTEXT_SSH_KEY: ${{ secrets.DOCKER_CONTEXT_SSH_KEY }}
       DOCKER_CONTEXT: ${{ secrets.DOCKER_CONTEXT }}


### PR DESCRIPTION
The workflows for deploying to development, pre-production, and production environments now explicitly reference the main branch of the deploy-workflow.yml file. This ensures that the latest changes in the deployment workflow are used, improving consistency and reliability in the deployment process.