### PR TITLE
fix(OnboardingConfig.kt): update property placeholders to use hyphens instead of camel case for consistency

### DIFF
--- a/platform/identity/f2/user-f2/user-f2-api/src/main/kotlin/io/komune/registry/f2/user/api/config/OnboardingConfig.kt
+++ b/platform/identity/f2/user-f2/user-f2-api/src/main/kotlin/io/komune/registry/f2/user/api/config/OnboardingConfig.kt
@@ -5,10 +5,10 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class OnboardingConfig {
-    @Value("\${platform.identity.onboarding.defaultRoles.organization}")
+    @Value("\${platform.identity.onboarding.default-roles.organization}")
     private lateinit var defaultOrganizationRolesStr: String
 
-    @Value("\${platform.identity.onboarding.defaultRoles.user}")
+    @Value("\${platform.identity.onboarding.default-roles.user}")
     private lateinit var defaultUserRolesStr: String
 
     val defaultOrganizationRoles by lazy { defaultOrganizationRolesStr.parseList() }


### PR DESCRIPTION
The property placeholders for default roles are changed from camel case to hyphenated format to align with the naming conventions used in the configuration files. This improves readability and consistency across the application configuration.