### PR TITLE
feat(LoginConfigTotp): add totpSecret to initialValues and form fields for TOTP configuration

### DIFF
--- a/platform/web/packages/keycloak/src/login/Pages/LoginConfigTotp.tsx
+++ b/platform/web/packages/keycloak/src/login/Pages/LoginConfigTotp.tsx
@@ -18,6 +18,7 @@ export default function LoginConfigTotp(props: PageProps<Extract<KcContext, { pa
 
   const initialValues = useMemo(() => ({
     mode: mode,
+    totpSecret: totp.totpSecret
   }), [mode, totp])
 
 
@@ -62,6 +63,7 @@ export default function LoginConfigTotp(props: PageProps<Extract<KcContext, { pa
       label: msgStr("authenticatorCode"),
       validator: validators.requiredField(t)
     }, {
+      key: "totpSecret",
       name: "totpSecret",
       type: "hidden"
     }, ...maybeAddItem<FormComposableField>(!!mode, {


### PR DESCRIPTION
The totpSecret is now included in the initialValues to ensure it is part of the component's state management. Additionally, adding the key for totpSecret in the form fields allows for better handling and validation of the TOTP secret, improving the overall user experience during the login configuration process.