### PR TITLE
chore(docker-compose): format JSON features array for better readability

### DIFF
--- a/infra/docker-compose/config/space-config.json
+++ b/infra/docker-compose/config/space-config.json
@@ -40,16 +40,18 @@
       "webUrl": "${PUBLIC_URL_ADMIN}"
     }
   ],
-  "features": [{
-    "name": "rg_feat_catalogue",
-    "description": "Access to catalogue and dataset features"
-  }, {
-    "name": "rg_feat_catalogue_audit",
-    "description": "Access to catalogue audition features"
-  }, {
-    "name": "rg_feat_configuration",
-    "description": "Access to platform configurations"
-  }],
+  "features": [
+    {
+      "name": "rg_feat_catalogue",
+      "description": "Access to catalogue and dataset features"
+    }, {
+      "name": "rg_feat_catalogue_audit",
+      "description": "Access to catalogue audition features"
+    }, {
+      "name": "rg_feat_configuration",
+      "description": "Access to platform configurations"
+    }
+  ],
   "permissions": [{
     "name": "fs_file_read",
     "description": "Ability to read files from the filesystem."

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftSnapMeiliSearchRepository.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftSnapMeiliSearchRepository.kt
@@ -31,6 +31,9 @@ class CatalogueDraftSnapMeiliSearchRepository(
     CatalogueDraftSearchableEntity::class,
 ) {
 
+    private val store = config.eventStore()
+    private val loader = ViewLoader(store, config.view)
+
     override val searchableAttributes = arrayOf(
         CatalogueDraftSearchableEntity::originalCatalogueIdentifier.name,
         CatalogueDraftSearchableEntity::title.name
@@ -54,9 +57,6 @@ class CatalogueDraftSnapMeiliSearchRepository(
             val existingDraft = get(entity.id)
 
             if (existingDraft == null) {
-                val store = config.eventStore()
-                val loader = ViewLoader(store, config.view)
-
                 val draftedCatalogue = loader.load(entity.catalogueId)!!
                 val originalCatalogue = loader.load(entity.originalCatalogueId)!!
 

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftSnapMeiliSearchRepository.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftSnapMeiliSearchRepository.kt
@@ -9,6 +9,7 @@ import io.komune.registry.api.commons.utils.toJson
 import io.komune.registry.infra.meilisearch.config.MeiliSearchSnapRepository
 import io.komune.registry.infra.meilisearch.config.match
 import io.komune.registry.program.s2.catalogue.api.CatalogueFinderService
+import io.komune.registry.program.s2.catalogue.api.config.CatalogueAutomateConfig
 import io.komune.registry.s2.catalogue.domain.model.FacetPage
 import io.komune.registry.s2.catalogue.draft.domain.CatalogueDraftState
 import io.komune.registry.s2.catalogue.draft.domain.model.CatalogueDraftMeiliSearchField
@@ -20,10 +21,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
 import kotlin.reflect.KCallable
+import s2.sourcing.dsl.view.ViewLoader
 
 @Service
 class CatalogueDraftSnapMeiliSearchRepository(
-    private val catalogueFinderService: CatalogueFinderService,
+    private val config: CatalogueAutomateConfig,
 ) : MeiliSearchSnapRepository<CatalogueDraftSearchableEntity>(
     MeiliIndex.CATALOGUE_DRAFTS,
     CatalogueDraftSearchableEntity::class,
@@ -52,8 +54,11 @@ class CatalogueDraftSnapMeiliSearchRepository(
             val existingDraft = get(entity.id)
 
             if (existingDraft == null) {
-                val draftedCatalogue = catalogueFinderService.get(entity.catalogueId)
-                val originalCatalogue = catalogueFinderService.get(entity.originalCatalogueId)
+                val store = config.eventStore()
+                val loader = ViewLoader(store, config.view)
+
+                val draftedCatalogue = loader.load(entity.catalogueId)!!
+                val originalCatalogue = loader.load(entity.originalCatalogueId)!!
 
                 val document = CatalogueDraftSearchableEntity(
                     id = entity.id,


### PR DESCRIPTION
feat(catalogue-draft): inject CatalogueAutomateConfig into CatalogueDraftSnapMeiliSearchRepository for improved configuration management The JSON features array is reformatted to enhance readability and maintainability. The CatalogueDraftSnapMeiliSearchRepository now uses CatalogueAutomateConfig to manage configurations, allowing for better separation of concerns and easier adjustments to the repository's behavior based on configuration changes.