### PR TITLE
chore(docker): split registry services into separate variables for clarity and maintainability

### DIFF
--- a/infra/docker-compose-deploy/.env_dev_default
+++ b/infra/docker-compose-deploy/.env_dev_default
@@ -20,7 +20,8 @@ PUBLIC_URL_KC=https://${HOST_NAME_CONNECT_AUTH}
 
 # Docker
 DOCKER_COMPOSE_PROXY_FILE=traefik
-DOCKER_COMPOSE_REGISTRY_FILE=redis meilisearch postgres registry-gateway registry-web
+DOCKER_COMPOSE_REGISTRY_DB_FILE=redis meilisearch postgres
+DOCKER_COMPOSE_REGISTRY_FILE=registry-gateway registry-web
 DOCKER_COMPOSE_CONNECT_FILE=postgres minio fake-smtp keycloak connect-admin im fs
 DOCKER_COMPOSE_REGISTRY_INIT_FILE=registry-init
 

--- a/infra/docker-compose-deploy/dev-compose.mk
+++ b/infra/docker-compose-deploy/dev-compose.mk
@@ -32,6 +32,11 @@ connect-init:
 	$(eval SERVICE := $(filter $(DOCKER_COMPOSE_INIT_FILE),$(MAKECMDGOALS)))
 	$(MAKE) $(MAKE_OPTS) --no-print-directory exec-common SERVICE=$(SERVICE) SERVICES_ALL="$(DOCKER_COMPOSE_INIT_FILE)"
 
+registry-db:
+	$(eval ACTION := $(filter $(ACTIONS),$(MAKECMDGOALS)))
+	$(eval SERVICE := $(filter $(DOCKER_COMPOSE_FILE),$(MAKECMDGOALS)))
+	$(MAKE) $(MAKE_OPTS) --no-print-directory exec-common ACTION=$(ACTION) SERVICE=$(SERVICE) SERVICES_ALL="$(DOCKER_COMPOSE_REGISTRY_DB_FILE)"
+
 registry:
 	$(eval ACTION := $(filter $(ACTIONS),$(MAKECMDGOALS)))
 	$(eval SERVICE := $(filter $(DOCKER_COMPOSE_FILE),$(MAKECMDGOALS)))


### PR DESCRIPTION
feat(docker): add new target for registry-db in dev-compose.mk to manage database services The changes separate the registry services into distinct variables, enhancing clarity and maintainability of the Docker configuration. A new target for registry-db is introduced in the Makefile to facilitate the management of database services, making it easier to work with specific components in the development environment.