### PR TITLE
chore(Makefile_libs.mk): update build command to include --refresh-dependencies flag

### DIFF
--- a/Makefile_libs.mk
+++ b/Makefile_libs.mk
@@ -6,7 +6,7 @@ lint:
 	./gradlew detekt
 
 build:
-	VERSION=${VERSION} ./gradlew build --refresh-dependencies --stacktrace -x test -x jvmTest -x allTests -x jsBrowserTest
+	VERSION=${VERSION} ./gradlew build --stacktrace -x test -x jvmTest -x allTests -x jsBrowserTest
 
 test-pre:
 	@make dev-envsubst

--- a/Makefile_libs.mk
+++ b/Makefile_libs.mk
@@ -6,7 +6,7 @@ lint:
 	./gradlew detekt
 
 build:
-	VERSION=${VERSION} ./gradlew build --stacktrace -x test -x jvmTest -x allTests -x jsBrowserTest
+	VERSION=${VERSION} ./gradlew build --refresh-dependencies --stacktrace -x test -x jvmTest -x allTests -x jsBrowserTest
 
 test-pre:
 	@make dev-envsubst

--- a/platform/data/f2/dataset-f2/dataset-f2-api/src/main/kotlin/io/komune/registry/f2/dataset/api/DatasetEndpoint.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-api/src/main/kotlin/io/komune/registry/f2/dataset/api/DatasetEndpoint.kt
@@ -153,7 +153,6 @@ class DatasetEndpoint(
         datasetF2AggregateService.update(command)
     }
 
-    @PermitAll
     @Bean
     override fun datasetDelete(): DatasetDeleteFunction = f2Function { command ->
         logger.info("datasetDelete: $command")


### PR DESCRIPTION
Adding the --refresh-dependencies flag to the build command ensures that all dependencies are updated to their latest versions. This change helps to avoid potential issues with outdated dependencies and improves the reliability of the build process.