### PR TITLE
fix(query.ts): change download distribution format from "json" to "text" to align with API requirements

### DIFF
--- a/platform/api/api-config/src/main/kotlin/io/komune/registry/api/config/flag/FlagConfiguration.kt
+++ b/platform/api/api-config/src/main/kotlin/io/komune/registry/api/config/flag/FlagConfiguration.kt
@@ -4,6 +4,7 @@ import f2.dsl.fnc.F2SupplierSingle
 import f2.dsl.fnc.f2Function
 import f2.dsl.fnc.f2SupplierSingle
 import jakarta.annotation.security.PermitAll
+import java.net.URI
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -15,7 +16,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.expression.BeanFactoryResolver
 import org.springframework.messaging.Message
-import java.net.URI
 
 @EnableConfigurationProperties(FlagProperties::class)
 @Configuration(proxyBeanMethods = false)

--- a/platform/commons/src/commonMain/kotlin/io/komune/registry/s2/commons/model/Location.kt
+++ b/platform/commons/src/commonMain/kotlin/io/komune/registry/s2/commons/model/Location.kt
@@ -1,7 +1,7 @@
 package io.komune.registry.s2.commons.model
 
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @JsExport
 interface LocationDTO {

--- a/platform/commons/src/jvmMain/kotlin/io/komune/registry/api/commons/utils/KotlinUtils.kt
+++ b/platform/commons/src/jvmMain/kotlin/io/komune/registry/api/commons/utils/KotlinUtils.kt
@@ -1,8 +1,6 @@
 package io.komune.registry.api.commons.utils
 
-import f2.dsl.fnc.operators.Batch
 import f2.dsl.fnc.operators.CHUNK_DEFAULT_SIZE
-import f2.dsl.fnc.operators.batch
 import f2.dsl.fnc.operators.flattenConcurrently
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async

--- a/platform/control/f2/activity-f2/activity-f2-api/src/main/kotlin/io/komune/registry/f2/activity/api/ActivityEndpoint.kt
+++ b/platform/control/f2/activity-f2/activity-f2-api/src/main/kotlin/io/komune/registry/f2/activity/api/ActivityEndpoint.kt
@@ -9,7 +9,6 @@ import f2.dsl.fnc.f2Function
 import f2.dsl.fnc.invokeWith
 import io.komune.fs.s2.file.client.FileClient
 import io.komune.fs.spring.utils.serveFile
-import io.komune.registry.s2.commons.exception.NotFoundException
 import io.komune.registry.f2.activity.api.service.ActivityF2ExecutorService
 import io.komune.registry.f2.activity.api.service.ActivityF2FinderService
 import io.komune.registry.f2.activity.api.service.ActivityPoliciesEnforcer
@@ -26,6 +25,7 @@ import io.komune.registry.f2.activity.domain.command.ActivityStepFulfilledEventD
 import io.komune.registry.f2.activity.domain.query.ActivityPageFunction
 import io.komune.registry.f2.activity.domain.query.ActivityStepEvidenceDownloadQuery
 import io.komune.registry.f2.activity.domain.query.ActivityStepPageFunction
+import io.komune.registry.s2.commons.exception.NotFoundException
 import jakarta.annotation.security.PermitAll
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean

--- a/platform/control/f2/activity-f2/activity-f2-api/src/main/kotlin/io/komune/registry/f2/activity/api/service/ActivityF2FinderService.kt
+++ b/platform/control/f2/activity-f2/activity-f2-api/src/main/kotlin/io/komune/registry/f2/activity/api/service/ActivityF2FinderService.kt
@@ -4,7 +4,6 @@ import cccev.dsl.client.CCCEVClient
 import cccev.dsl.client.model.unflatten
 import cccev.dsl.model.Certification
 import cccev.dsl.model.CertificationId
-import cccev.dsl.model.InformationConcept
 import cccev.dsl.model.InformationConceptDTO
 import cccev.dsl.model.Requirement
 import cccev.dsl.model.RequirementId

--- a/platform/control/f2/dcs-f2/dcs-f2-api/src/main/kotlin/io/komune/registry/f2/dcs/api/converter/DcsToCccevConverter.kt
+++ b/platform/control/f2/dcs-f2/dcs-f2-api/src/main/kotlin/io/komune/registry/f2/dcs/api/converter/DcsToCccevConverter.kt
@@ -3,6 +3,7 @@ package io.komune.registry.f2.dcs.api.converter
 import cccev.dsl.model.DataUnit
 import cccev.dsl.model.DataUnitOption
 import cccev.dsl.model.DataUnitType
+import cccev.dsl.model.DataUnitTypeValues
 import cccev.dsl.model.Requirement
 import cccev.dsl.model.XSDBoolean
 import cccev.dsl.model.XSDDate
@@ -12,7 +13,6 @@ import cccev.dsl.model.builder.informationConcept
 import cccev.dsl.model.constraint
 import cccev.dsl.model.criterion
 import cccev.dsl.model.informationRequirement
-import cccev.dsl.model.DataUnitTypeValues
 import io.komune.registry.f2.dcs.api.model.DcsCode
 import io.komune.registry.f2.dcs.api.validator.DcsValidator
 import io.komune.registry.f2.dcs.domain.model.DataCollectionStep

--- a/platform/control/test/bdd/src/main/kotlin/io/komune/registry/control/test/bdd/f2/activity/command/ActivityCreateSteps.kt
+++ b/platform/control/test/bdd/src/main/kotlin/io/komune/registry/control/test/bdd/f2/activity/command/ActivityCreateSteps.kt
@@ -3,9 +3,9 @@ package io.komune.registry.control.test.bdd.f2.activity.command
 import f2.dsl.fnc.invokeWith
 import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
+import io.komune.registry.control.test.bdd.VerCucumberStepsDefinition
 import io.komune.registry.f2.activity.api.ActivityEndpoint
 import io.komune.registry.f2.activity.domain.command.ActivityCreateCommandDTOBase
-import io.komune.registry.control.test.bdd.VerCucumberStepsDefinition
 import java.util.UUID
 import org.springframework.beans.factory.annotation.Autowired
 import s2.bdd.data.TestContextKey

--- a/platform/control/test/bdd/src/main/kotlin/io/komune/registry/control/test/bdd/f2/dcs/command/DcsDefineF2Steps.kt
+++ b/platform/control/test/bdd/src/main/kotlin/io/komune/registry/control/test/bdd/f2/dcs/command/DcsDefineF2Steps.kt
@@ -8,11 +8,11 @@ import cccev.f2.requirement.query.RequirementGetByIdentifierQuery
 import f2.dsl.fnc.invokeWith
 import io.cucumber.java8.En
 import io.komune.registry.api.commons.utils.parseFile
+import io.komune.registry.control.test.bdd.VerCucumberStepsDefinition
 import io.komune.registry.f2.dcs.api.DcsEndpoint
 import io.komune.registry.f2.dcs.domain.command.DataCollectionStepDefineCommand
 import io.komune.registry.f2.dcs.domain.model.DataCollectionStep
 import io.komune.registry.f2.dcs.domain.query.DataCollectionStepGetQuery
-import io.komune.registry.control.test.bdd.VerCucumberStepsDefinition
 import kotlin.reflect.jvm.javaMethod
 import org.springframework.beans.factory.annotation.Autowired
 

--- a/platform/data/dsl/dcat/src/commonMain/kotlin/io/komune/registry/dsl/dcat/domain/model/ApCatalog.kt
+++ b/platform/data/dsl/dcat/src/commonMain/kotlin/io/komune/registry/dsl/dcat/domain/model/ApCatalog.kt
@@ -4,8 +4,8 @@ import io.komune.registry.dsl.skos.domain.model.SkosConcept
 import io.komune.registry.dsl.skos.domain.model.SkosConceptScheme
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.structure.domain.model.Structure
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @JsExport
 interface DcatApCatalogue: CataloguedResource {

--- a/platform/data/dsl/skos/src/commonMain/kotlin/io/komune/registry/dsl/skos/domain/model/Skos.kt
+++ b/platform/data/dsl/skos/src/commonMain/kotlin/io/komune/registry/dsl/skos/domain/model/Skos.kt
@@ -1,7 +1,7 @@
 package io.komune.registry.dsl.skos.domain.model
 
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class SkosContext(

--- a/platform/data/dsl/structure/src/commonMain/kotlin/io/komune/registry/s2/structure/domain/model/Strucute.kt
+++ b/platform/data/dsl/structure/src/commonMain/kotlin/io/komune/registry/s2/structure/domain/model/Strucute.kt
@@ -1,7 +1,7 @@
 package io.komune.registry.s2.structure.domain.model
 
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 typealias StructureId = String
 

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/draft/api/service/CatalogueDraftF2AggregateService.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/draft/api/service/CatalogueDraftF2AggregateService.kt
@@ -21,8 +21,8 @@ import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftSubmit
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.dataset.domain.command.DatasetAddDistributionCommand
 import io.komune.registry.s2.dataset.domain.command.DatasetLinkDatasetsCommand
-import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
+import org.springframework.stereotype.Service
 
 @Service
 class CatalogueDraftF2AggregateService(

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftCreateCommandDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftCreateCommandDTO.kt
@@ -5,8 +5,8 @@ import io.komune.registry.f2.catalogue.draft.domain.model.CatalogueDraftDTO
 import io.komune.registry.f2.catalogue.draft.domain.model.CatalogueDraftDTOBase
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a draft.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftDeleteCommandDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftDeleteCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.catalogue.draft.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftDeleteCommand
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Delete a draft.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftRejectCommandDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftRejectCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.catalogue.draft.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftRejectCommand
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Reject a draft.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftRequestUpdateCommandDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftRequestUpdateCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.catalogue.draft.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftRequestUpdateCommand
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Request an update to a draft.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftSubmitCommandDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftSubmitCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.catalogue.draft.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftSubmitCommand
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Submit a draft for validation.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftValidateCommandDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/command/CatalogueDraftValidateCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.catalogue.draft.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftValidateCommand
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Validate a draft.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/model/CatalogueDraftDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/model/CatalogueDraftDTO.kt
@@ -9,8 +9,8 @@ import io.komune.registry.s2.catalogue.draft.domain.CatalogueDraftState
 import io.komune.registry.s2.commons.model.CatalogueDraftId
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 model

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/query/CatalogueDraftGetQueryDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/query/CatalogueDraftGetQueryDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.catalogue.draft.domain.model.CatalogueDraftDTO
 import io.komune.registry.f2.catalogue.draft.domain.model.CatalogueDraftDTOBase
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a catalogue draft by id.

--- a/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/query/CatalogueDraftPageQueryDTO.kt
+++ b/platform/data/f2/catalogue-draft-f2/catalogue-draft-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/draft/domain/query/CatalogueDraftPageQueryDTO.kt
@@ -8,8 +8,8 @@ import io.komune.registry.s2.catalogue.draft.domain.CatalogueDraftState
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.commons.model.UserId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a filtered page of catalogue drafts.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CatalogueCachedService.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CatalogueCachedService.kt
@@ -5,9 +5,9 @@ import io.komune.registry.f2.dataset.api.service.DatasetF2FinderService
 import io.komune.registry.f2.license.api.service.LicenseF2FinderService
 import io.komune.registry.f2.organization.api.service.OrganizationF2FinderService
 import io.komune.registry.f2.user.api.service.UserF2FinderService
+import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Autowired
-import kotlin.coroutines.coroutineContext
 
 open class CatalogueCachedService {
 

--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/resources/catalogues/100m-chart.json
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/resources/catalogues/100m-chart.json
@@ -1,0 +1,19 @@
+{
+  "type": "100m-chart",
+  "identifierSequence": {
+    "name": "seq_100m_chart",
+    "startValue": 50
+  },
+  "parentTypes": ["100m-charts"],
+  "conceptSchemes": [],
+  "ownerRoles": ["rg_role_org_contributor"],
+  "structure": "item",
+  "i18n": {
+    "enable": true,
+    "translationType": "100m-translation",
+    "datasets": [{
+      "type": "data",
+      "identifierSuffix": "-data"
+    }]
+  }
+}

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueCreateCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueCreateCommandDTO.kt
@@ -13,9 +13,9 @@ import io.komune.registry.s2.commons.model.SimpleFile
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.structure.domain.model.Structure
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Create a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueLinkCataloguesCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueLinkCataloguesCommandDTO.kt
@@ -3,9 +3,9 @@ package io.komune.registry.f2.catalogue.domain.command
 import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.CatalogueId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Create a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueLinkDatasetCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueLinkDatasetCommandDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.DatasetId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Create a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueLinkThemesCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueLinkThemesCommandDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.concept.domain.ConceptId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Links themes to a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueSetImageFunction.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueSetImageFunction.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.fs.s2.file.domain.model.FilePath
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.SimpleFile
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueUnlinkCataloguesCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueUnlinkCataloguesCommandDTO.kt
@@ -3,9 +3,9 @@ package io.komune.registry.f2.catalogue.domain.command
 import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.CatalogueId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Create a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueUpdateAccessRightsCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueUpdateAccessRightsCommandDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.catalogue.domain.command.CatalogueUpdateAccessRightsCommand
 import io.komune.registry.s2.commons.model.CatalogueId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update the access rights of a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueUpdateCommandDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/command/CatalogueUpdateCommandDTO.kt
@@ -12,8 +12,8 @@ import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.structure.domain.model.Structure
 import io.komune.registry.s2.structure.domain.model.StructureDTO
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueAccessDataDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueAccessDataDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.catalogue.domain.dto
 import io.komune.registry.f2.organization.domain.model.OrganizationRefDTO
 import io.komune.registry.f2.user.domain.model.UserRefDTO
 import io.komune.registry.s2.catalogue.domain.model.CatalogueAccessRight
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @JsExport
 interface CatalogueAccessDataDTO {

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueDTO.kt
@@ -18,8 +18,8 @@ import io.komune.registry.s2.commons.model.Location
 import io.komune.registry.s2.commons.model.LocationDTO
 import io.komune.registry.s2.structure.domain.model.Structure
 import io.komune.registry.s2.structure.domain.model.StructureDTO
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * dcat:Catalog represents a catalog, which is a dataset in which each individual item is a metadata record

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueDraftRefDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueDraftRefDTO.kt
@@ -6,8 +6,8 @@ import io.komune.registry.s2.catalogue.draft.domain.CatalogueDraftState
 import io.komune.registry.s2.commons.model.CatalogueDraftId
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @JsExport
 interface CatalogueDraftRefDTO {

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueRefDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueRefDTO.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.f2.catalogue.domain.dto
 
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Minimal information about a [Catalogue][CatalogueDTO]

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueRefTreeDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/dto/CatalogueRefTreeDTO.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.f2.catalogue.domain.dto
 
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Minimal information about a [Catalogue][CatalogueDTO] with children's refs.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueGetByIdentifierQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueGetByIdentifierQueryDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTO
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTOBase
 import io.komune.registry.s2.commons.model.CatalogueIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get a catalogue by composite identifier.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueGetQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueGetQueryDTO.kt
@@ -5,9 +5,9 @@ import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTO
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTOBase
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get a catalogue by id.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueListAvailableOwnersQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueListAvailableOwnersQueryDTO.kt
@@ -3,9 +3,9 @@ package io.komune.registry.f2.catalogue.domain.query
 import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.organization.domain.model.OrganizationRef
 import io.komune.registry.f2.organization.domain.model.OrganizationRefDTO
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * List available owners for a given type of catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueListAvailableParentsQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueListAvailableParentsQueryDTO.kt
@@ -5,9 +5,9 @@ import io.komune.registry.f2.catalogue.domain.dto.CatalogueRefDTO
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueRefDTOBase
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * List available parents catalogues for a given type of catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueListAvailableThemesQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueListAvailableThemesQueryDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.concept.domain.model.ConceptTranslatedDTO
 import io.komune.registry.f2.concept.domain.model.ConceptTranslatedDTOBase
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * List available themes for a given type of catalogue.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueRefGetTreeQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueRefGetTreeQueryDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueRefTreeDTO
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueRefTreeDTOBase
 import io.komune.registry.s2.commons.model.CatalogueIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get a catalogue tree by identifier.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueRefListQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueRefListQueryDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueRefDTO
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueRefDTOBase
 import io.komune.registry.s2.commons.model.Language
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get a page of activities.

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueSearchQueryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueSearchQueryDTO.kt
@@ -4,9 +4,7 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTO
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTOBase
 import io.komune.registry.s2.catalogue.domain.model.DistributionPageDTO
-import io.komune.registry.s2.catalogue.domain.model.FacetDistribution
 import io.komune.registry.s2.catalogue.domain.model.FacetDistributionDTO
-import io.komune.registry.s2.catalogue.domain.model.FacetPageDTO
 import kotlin.js.JsExport
 import kotlin.js.JsName
 

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/command/ConceptCreateCommandDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/command/ConceptCreateCommandDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.concept.domain.ConceptIdentifier
 import io.komune.registry.s2.concept.domain.command.ConceptCreateCommand
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a concept.

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/command/ConceptUpdateCommandDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/command/ConceptUpdateCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.concept.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.concept.domain.command.ConceptUpdateCommand
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a concept.

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/model/ConceptDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/model/ConceptDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.concept.domain.model
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.concept.domain.ConceptIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 model

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/model/ConceptTranslatedDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/model/ConceptTranslatedDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.concept.domain.model
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.concept.domain.ConceptIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Translated version of a concept.

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/query/ConceptGetByIdentifierQueryDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/query/ConceptGetByIdentifierQueryDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.concept.domain.model.ConceptDTO
 import io.komune.registry.f2.concept.domain.model.ConceptDTOBase
 import io.komune.registry.s2.concept.domain.ConceptIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a concept by identifier.

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/query/ConceptGetQueryDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/query/ConceptGetQueryDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.concept.domain.query
 import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.concept.domain.model.ConceptDTO
 import io.komune.registry.s2.concept.domain.ConceptId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a concept by id.

--- a/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/query/ConceptGetTranslatedQueryDTO.kt
+++ b/platform/data/f2/concept-f2/concept-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/concept/domain/query/ConceptGetTranslatedQueryDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.concept.domain.model.ConceptTranslatedDTO
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.concept.domain.ConceptId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a translated concept by id.

--- a/platform/data/f2/dataset-f2/dataset-f2-api/src/main/kotlin/io/komune/registry/f2/dataset/api/service/DatasetF2AggregateService.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-api/src/main/kotlin/io/komune/registry/f2/dataset/api/service/DatasetF2AggregateService.kt
@@ -44,9 +44,9 @@ import io.komune.registry.s2.dataset.domain.command.DatasetRemoveDistributionCom
 import io.komune.registry.s2.dataset.domain.command.DatasetUnlinkDatasetsCommand
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdateDistributionCommand
 import io.ktor.utils.io.core.toByteArray
+import java.util.UUID
 import org.springframework.http.codec.multipart.FilePart
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class DatasetF2AggregateService(

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetAddJsonDistributionCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetAddJsonDistributionCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.dataset.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.dataset.domain.model.DistributionId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Add a distribution with json content to a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetAddMediaDistributionCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetAddMediaDistributionCommandDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.commons.model.SimpleFile
 import io.komune.registry.s2.dataset.domain.model.DistributionId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Add a distribution with media content to a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetCreateCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetCreateCommandDTO.kt
@@ -9,9 +9,9 @@ import io.komune.registry.dsl.skos.domain.model.SkosConceptScheme
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.commons.model.DatasetIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Create a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetLinkDatasetsCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetLinkDatasetsCommandDTO.kt
@@ -3,9 +3,9 @@ package io.komune.registry.f2.dataset.domain.command
 import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Create a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetLinkThemesCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetLinkThemesCommandDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.dsl.skos.domain.model.SkosConcept
 import io.komune.registry.s2.commons.model.DatasetId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 
 /**

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetRemoveDistributionCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetRemoveDistributionCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.dataset.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.dataset.domain.model.DistributionId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Remove a distribution from a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetSetImageFunction.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetSetImageFunction.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.dataset.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.fs.s2.file.domain.model.FilePath
 import io.komune.registry.s2.commons.model.DatasetId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetUpdateCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetUpdateCommandDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.cqrs.Event
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.commons.model.DatasetIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Update a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetUpdateJsonDistributionCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetUpdateJsonDistributionCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.dataset.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.dataset.domain.model.DistributionId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a distribution with json content to a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetUpdateMediaDistributionCommandDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/command/DatasetUpdateMediaDistributionCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.dataset.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.dataset.domain.model.DistributionId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a distribution with media content to a dataset.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/dto/DatasetDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/dto/DatasetDTO.kt
@@ -6,8 +6,8 @@ import io.komune.registry.dsl.skos.domain.model.SkosConcept
 import io.komune.registry.dsl.skos.domain.model.SkosConceptDTO
 import io.komune.registry.dsl.skos.domain.model.SkosConceptScheme
 import io.komune.registry.s2.dataset.domain.automate.DatasetState
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * dcat:Dataset represents a collection of data, published or curated by a single agent or identifiable community.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/dto/DistributionDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/dto/DistributionDTO.kt
@@ -2,8 +2,8 @@ package io.komune.registry.f2.dataset.domain.dto
 
 import io.komune.fs.s2.file.domain.model.FilePath
 import io.komune.registry.s2.dataset.domain.model.DistributionId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 model

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetDataQuery.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetDataQuery.kt
@@ -2,10 +2,10 @@ package io.komune.registry.f2.dataset.domain.query
 
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetId
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 
 /**

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetGetByIdentifierQueryDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetGetByIdentifierQueryDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.dataset.domain.dto.DatasetDTO
 import io.komune.registry.f2.dataset.domain.dto.DatasetDTOBase
 import io.komune.registry.s2.commons.model.DatasetIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get a dataset by composite identifier.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetGetQueryDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetGetQueryDTO.kt
@@ -4,9 +4,9 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.dataset.domain.dto.DatasetDTO
 import io.komune.registry.f2.dataset.domain.dto.DatasetDTOBase
 import io.komune.registry.s2.commons.model.DatasetId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get a dataset by id.

--- a/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetListLanguagesQueryDTO.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/dataset/domain/query/DatasetListLanguagesQueryDTO.kt
@@ -2,9 +2,9 @@ package io.komune.registry.f2.dataset.domain.query
 
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.DatasetIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Serializable
 
 /**
  * Get available languages of a dataset by identifier.

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/command/LicenseCreateCommandDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/command/LicenseCreateCommandDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.license.domain.LicenseIdentifier
 import io.komune.registry.s2.license.domain.command.LicenseCreateCommand
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a license.

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/command/LicenseUpdateCommandDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/command/LicenseUpdateCommandDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.license.domain.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.license.domain.command.LicenseUpdateCommand
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a license.

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/model/LicenseDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/model/LicenseDTO.kt
@@ -2,8 +2,8 @@ package io.komune.registry.f2.license.domain.model
 
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.license.domain.LicenseIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 model

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseGetByIdentifierQueryDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseGetByIdentifierQueryDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.license.domain.model.LicenseDTO
 import io.komune.registry.f2.license.domain.model.LicenseDTOBase
 import io.komune.registry.s2.license.domain.LicenseIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a license by identifier.

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseGetQueryDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseGetQueryDTO.kt
@@ -4,8 +4,8 @@ import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.license.domain.model.LicenseDTO
 import io.komune.registry.f2.license.domain.model.LicenseDTOBase
 import io.komune.registry.s2.license.domain.LicenseId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Get a license by id.

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseListQueryDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseListQueryDTO.kt
@@ -3,8 +3,8 @@ package io.komune.registry.f2.license.domain.query
 import f2.dsl.fnc.F2Function
 import io.komune.registry.f2.license.domain.model.LicenseDTO
 import io.komune.registry.f2.license.domain.model.LicenseDTOBase
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * List all licenses.

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/CatalogueDraftAggregateService.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/CatalogueDraftAggregateService.kt
@@ -14,8 +14,8 @@ import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftSubmit
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftSubmittedEvent
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftValidateCommand
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftValidatedEvent
-import org.springframework.stereotype.Service
 import java.util.UUID
+import org.springframework.stereotype.Service
 
 @Service
 class CatalogueDraftAggregateService(

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftAutomateConfig.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftAutomateConfig.kt
@@ -6,11 +6,11 @@ import io.komune.registry.s2.catalogue.draft.domain.CatalogueDraftState
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftEvent
 import io.komune.registry.s2.catalogue.draft.domain.s2CatalogueDraft
 import io.komune.registry.s2.commons.model.CatalogueDraftId
+import kotlin.reflect.KClass
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import kotlin.reflect.KClass
-import org.springframework.core.annotation.Order
 
 @Order(20)
 @Configuration

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftAutomateConfig.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftAutomateConfig.kt
@@ -23,10 +23,8 @@ class CatalogueDraftAutomateConfig(
 	aggregate,
 	evolver,
 	projectSnapRepository,
-	entityName = "CatalogueDraft"
+	CatalogueDraftEntity::class
 ) {
-	override fun redisEntityType() = CatalogueDraftEntity::class
-
 	override fun automate() = s2CatalogueDraft
 	override fun entityType(): KClass<CatalogueDraftEvent> = CatalogueDraftEvent::class
 }

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftAutomateConfig.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftAutomateConfig.kt
@@ -1,6 +1,6 @@
 package io.komune.registry.s2.catalogue.draft.api.entity
 
-import io.komune.registry.infra.postgresql.RegistryS2SourcingSpringDataAdapter
+import io.komune.registry.infra.redis.RegistryS2SourcingSpringDataAdapter
 import io.komune.registry.s2.catalogue.draft.api.CatalogueDraftEvolver
 import io.komune.registry.s2.catalogue.draft.domain.CatalogueDraftState
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftEvent
@@ -19,12 +19,14 @@ class CatalogueDraftAutomateConfig(
 	evolver: CatalogueDraftEvolver,
 	projectSnapRepository: CatalogueDraftSnapRepository
 ): RegistryS2SourcingSpringDataAdapter<
-		CatalogueDraftEntity, CatalogueDraftState, CatalogueDraftEvent, CatalogueDraftId, CatalogueDraftAutomateExecutor>(
+        CatalogueDraftEntity, CatalogueDraftState, CatalogueDraftEvent, CatalogueDraftId, CatalogueDraftAutomateExecutor>(
 	aggregate,
 	evolver,
 	projectSnapRepository,
 	entityName = "CatalogueDraft"
 ) {
+	override fun redisEntityType() = CatalogueDraftEntity::class
+
 	override fun automate() = s2CatalogueDraft
 	override fun entityType(): KClass<CatalogueDraftEvent> = CatalogueDraftEvent::class
 }

--- a/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftSnapMeiliSearchRepository.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-api/src/main/kotlin/io/komune/registry/s2/catalogue/draft/api/entity/CatalogueDraftSnapMeiliSearchRepository.kt
@@ -16,10 +16,10 @@ import io.komune.registry.s2.catalogue.draft.domain.model.CatalogueDraftSearchab
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.MeiliIndex
 import io.komune.registry.s2.commons.model.UserId
+import kotlin.reflect.KCallable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.stereotype.Service
-import kotlin.reflect.KCallable
 import s2.sourcing.dsl.view.ViewLoader
 
 @Service

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/S2CatalogueDraft.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/S2CatalogueDraft.kt
@@ -12,11 +12,11 @@ import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftSubmit
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftSubmittedEvent
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftValidateCommand
 import io.komune.registry.s2.catalogue.draft.domain.command.CatalogueDraftValidatedEvent
+import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Role
 import s2.dsl.automate.S2State
 import s2.dsl.automate.builder.s2Sourcing
-import kotlin.js.JsExport
 
 val s2CatalogueDraft = s2Sourcing {
     name = "CatalogueDraft"

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftDeleteCommand.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftDeleteCommand.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.s2.catalogue.draft.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 command

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftMessage.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftMessage.kt
@@ -2,10 +2,10 @@ package io.komune.registry.s2.catalogue.draft.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueDraftId
 import io.komune.registry.s2.commons.model.S2SourcingEvent
+import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2InitCommand
-import kotlin.js.JsExport
 
 @JsExport
 @Serializable

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftRejectCommand.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftRejectCommand.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.s2.catalogue.draft.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 command

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftRequestUpdateCommand.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftRequestUpdateCommand.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.s2.catalogue.draft.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 command

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftSubmitCommand.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftSubmitCommand.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.s2.catalogue.draft.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 command

--- a/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftValidateCommand.kt
+++ b/platform/data/s2/catalogue-draft/catalogue-draft-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/draft/domain/command/CatalogueDraftValidateCommand.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.s2.catalogue.draft.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueDraftId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 command

--- a/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/config/CatalogueAutomateConfig.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/config/CatalogueAutomateConfig.kt
@@ -1,6 +1,6 @@
 package io.komune.registry.program.s2.catalogue.api.config
 
-import io.komune.registry.infra.postgresql.RegistryS2SourcingSpringDataAdapter
+import io.komune.registry.infra.redis.RegistryS2SourcingSpringDataAdapter
 import io.komune.registry.program.s2.catalogue.api.CatalogueEvolver
 import io.komune.registry.program.s2.catalogue.api.entity.CatalogueEntity
 import io.komune.registry.program.s2.catalogue.api.entity.CatalogueSnapRepository
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
 import kotlin.reflect.KClass
+import kotlinx.coroutines.runBlocking
 import org.springframework.core.annotation.Order
 
 @Order(30)
@@ -26,6 +27,8 @@ class CatalogueAutomateConfig(
 	projectSnapRepository,
 	"Catalogue"
 ) {
+	override fun redisEntityType()= CatalogueEntity::class
+
 	override fun automate() = s2Catalogue
 	override fun entityType(): KClass<CatalogueEvent> = CatalogueEvent::class
 }

--- a/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/config/CatalogueAutomateConfig.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/config/CatalogueAutomateConfig.kt
@@ -25,10 +25,8 @@ class CatalogueAutomateConfig(
 	aggregate,
 	evolver,
 	projectSnapRepository,
-	"Catalogue"
+	CatalogueEntity::class
 ) {
-	override fun redisEntityType()= CatalogueEntity::class
-
 	override fun automate() = s2Catalogue
 	override fun entityType(): KClass<CatalogueEvent> = CatalogueEvent::class
 }

--- a/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/config/CatalogueAutomateConfig.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/config/CatalogueAutomateConfig.kt
@@ -8,12 +8,11 @@ import io.komune.registry.s2.catalogue.domain.automate.CatalogueState
 import io.komune.registry.s2.catalogue.domain.automate.s2Catalogue
 import io.komune.registry.s2.catalogue.domain.command.CatalogueEvent
 import io.komune.registry.s2.commons.model.CatalogueId
+import kotlin.reflect.KClass
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import kotlin.reflect.KClass
-import kotlinx.coroutines.runBlocking
-import org.springframework.core.annotation.Order
 
 @Order(30)
 @Configuration

--- a/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/entity/CatalogueSnapMeiliSearchRepository.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/entity/CatalogueSnapMeiliSearchRepository.kt
@@ -54,32 +54,32 @@ class CatalogueSnapMeiliSearchRepository(
         CatalogueModel::modified.name
     )
 
-    suspend fun save(entity: CatalogueEntity) {
+    suspend fun save(entity: CatalogueEntity) = withContext(Dispatchers.IO) {
         if (entity.status == CatalogueState.DELETED) {
             remove(entity.id)
-            return
+            return@withContext
         }
 
         updateDraft(entity)
 
         if (!entity.type.contains("translation")) {
             logger.info("Skip catalogue: $entity, [type: ${entity.type}]")
-            return
+            return@withContext
         }
 
         val domain = catalogueI18nService.rebuildModel(entity)
 
         if (domain == null) {
             logger.info("Skip catalogue: $entity, [type: ${entity.type}]")
-            return
+            return@withContext
         }
         if (domain.hidden) {
             logger.info("Skip catalogue: $entity, [type: ${entity.type}] is hidden")
-            return
+            return@withContext
         }
         if (!indexedCatalogueTypes.contains(domain.type)) {
             logger.info("Skip catalogue: $entity, [type: ${entity.type}] is not contained in ${searchProperties.indexedCatalogue}")
-            return
+            return@withContext
         }
 
         logger.info("Index catalogue[${domain.id}, ${domain.identifier}], type: ${domain.type}")

--- a/platform/data/s2/catalogue/catalogue-api/src/test/kotlin/MeiliSearchTest.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/test/kotlin/MeiliSearchTest.kt
@@ -1,7 +1,6 @@
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.meilisearch.sdk.Client
 import com.meilisearch.sdk.Config
-import com.meilisearch.sdk.json.JacksonJsonHandler
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/platform/data/s2/catalogue/catalogue-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/domain/automate/S2Catalogue.kt
+++ b/platform/data/s2/catalogue/catalogue-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/domain/automate/S2Catalogue.kt
@@ -26,11 +26,11 @@ import io.komune.registry.s2.catalogue.domain.command.CatalogueUpdateVersionNote
 import io.komune.registry.s2.catalogue.domain.command.CatalogueUpdatedAccessRightsEvent
 import io.komune.registry.s2.catalogue.domain.command.CatalogueUpdatedEvent
 import io.komune.registry.s2.catalogue.domain.command.CatalogueUpdatedVersionNotesEvent
+import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Role
 import s2.dsl.automate.S2State
 import s2.dsl.automate.builder.s2Sourcing
-import kotlin.js.JsExport
 
 val s2Catalogue = s2Sourcing {
     name = "Catalogue"

--- a/platform/data/s2/catalogue/catalogue-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/domain/command/CatalogueMessage.kt
+++ b/platform/data/s2/catalogue/catalogue-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/domain/command/CatalogueMessage.kt
@@ -2,11 +2,11 @@ package io.komune.registry.s2.catalogue.domain.command
 
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.S2SourcingEvent
+import kotlin.js.JsExport
+import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2InitCommand
-import kotlin.js.JsExport
-import kotlin.js.JsName
 
 @JsExport
 @JsName("CatalogueEvent")

--- a/platform/data/s2/catalogue/catalogue-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/domain/command/CatalogueUpdateAccessRightsCommand.kt
+++ b/platform/data/s2/catalogue/catalogue-domain/src/commonMain/kotlin/io/komune/registry/s2/catalogue/domain/command/CatalogueUpdateAccessRightsCommand.kt
@@ -2,8 +2,8 @@ package io.komune.registry.s2.catalogue.domain.command
 
 import io.komune.registry.s2.catalogue.domain.model.CatalogueAccessRight
 import io.komune.registry.s2.commons.model.CatalogueId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * @d2 command

--- a/platform/data/s2/concept/concept-api/src/main/kotlin/io/komune/registry/s2/concept/api/ConceptAggregateService.kt
+++ b/platform/data/s2/concept/concept-api/src/main/kotlin/io/komune/registry/s2/concept/api/ConceptAggregateService.kt
@@ -5,8 +5,8 @@ import io.komune.registry.s2.concept.domain.command.ConceptCreateCommand
 import io.komune.registry.s2.concept.domain.command.ConceptCreatedEvent
 import io.komune.registry.s2.concept.domain.command.ConceptUpdateCommand
 import io.komune.registry.s2.concept.domain.command.ConceptUpdatedEvent
-import org.springframework.stereotype.Service
 import java.util.UUID
+import org.springframework.stereotype.Service
 
 @Service
 class ConceptAggregateService(

--- a/platform/data/s2/concept/concept-api/src/main/kotlin/io/komune/registry/s2/concept/api/entity/ConceptAutomateConfig.kt
+++ b/platform/data/s2/concept/concept-api/src/main/kotlin/io/komune/registry/s2/concept/api/entity/ConceptAutomateConfig.kt
@@ -1,5 +1,6 @@
 package io.komune.registry.s2.concept.api.entity
 
+import io.komune.registry.infra.redis.RegistryS2SourcingSpringDataAdapter
 import io.komune.registry.s2.concept.api.ConceptEvolver
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.concept.domain.ConceptState
@@ -11,11 +12,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import s2.spring.sourcing.data.S2SourcingSpringDataAdapter
 import kotlin.reflect.KClass
 
 @Configuration
@@ -23,29 +22,13 @@ class ConceptAutomateConfig(
     aggregate: ConceptAutomateExecutor,
     evolver: ConceptEvolver,
     projectSnapRepository: ConceptSnapRepository,
-    private val repository: ConceptRepository
-): S2SourcingSpringDataAdapter<ConceptEntity, ConceptState, ConceptEvent, ConceptId, ConceptAutomateExecutor>(
+): RegistryS2SourcingSpringDataAdapter<ConceptEntity, ConceptState, ConceptEvent, ConceptId, ConceptAutomateExecutor>(
 	aggregate,
 	evolver,
-	projectSnapRepository
+	projectSnapRepository,
+	ConceptEntity::class
 ) {
 
-	private val logger = LoggerFactory.getLogger(ConceptAutomateConfig::class.java)
-	override fun afterPropertiesSet() {
-		super.afterPropertiesSet()
-		if (repository.count() == 0L) {
-			try {
-				runBlocking {
-					logger.info("/////////////////////////")
-					logger.info("Replay Concept history")
-					executor.replayHistory()
-					logger.info("/////////////////////////")
-				}
-			} catch (e: Exception) {
-				logger.error("Replay history error", e)
-			}
-		}
-	}
 
 	override fun automate() = s2Concept
 

--- a/platform/data/s2/concept/concept-api/src/main/kotlin/io/komune/registry/s2/concept/api/entity/ConceptAutomateConfig.kt
+++ b/platform/data/s2/concept/concept-api/src/main/kotlin/io/komune/registry/s2/concept/api/entity/ConceptAutomateConfig.kt
@@ -8,14 +8,13 @@ import io.komune.registry.s2.concept.domain.command.ConceptCreatedEvent
 import io.komune.registry.s2.concept.domain.command.ConceptEvent
 import io.komune.registry.s2.concept.domain.command.ConceptUpdatedEvent
 import io.komune.registry.s2.concept.domain.s2Concept
-import kotlinx.coroutines.runBlocking
+import kotlin.reflect.KClass
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import kotlin.reflect.KClass
 
 @Configuration
 class ConceptAutomateConfig(

--- a/platform/data/s2/concept/concept-domain/src/commonMain/kotlin/io/komune/registry/s2/concept/domain/command/ConceptCreateCommand.kt
+++ b/platform/data/s2/concept/concept-domain/src/commonMain/kotlin/io/komune/registry/s2/concept/domain/command/ConceptCreateCommand.kt
@@ -3,8 +3,8 @@ package io.komune.registry.s2.concept.domain.command
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.concept.domain.ConceptId
 import io.komune.registry.s2.concept.domain.ConceptIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a concept.

--- a/platform/data/s2/concept/concept-domain/src/commonMain/kotlin/io/komune/registry/s2/concept/domain/command/ConceptMessage.kt
+++ b/platform/data/s2/concept/concept-domain/src/commonMain/kotlin/io/komune/registry/s2/concept/domain/command/ConceptMessage.kt
@@ -2,9 +2,9 @@ package io.komune.registry.s2.concept.domain.command
 
 import io.komune.registry.s2.commons.model.S2SourcingEvent
 import io.komune.registry.s2.concept.domain.ConceptId
+import kotlin.js.JsExport
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2InitCommand
-import kotlin.js.JsExport
 
 @JsExport
 sealed interface ConceptEvent: S2SourcingEvent<ConceptId>

--- a/platform/data/s2/concept/concept-domain/src/commonMain/kotlin/io/komune/registry/s2/concept/domain/command/ConceptUpdateCommand.kt
+++ b/platform/data/s2/concept/concept-domain/src/commonMain/kotlin/io/komune/registry/s2/concept/domain/command/ConceptUpdateCommand.kt
@@ -2,8 +2,8 @@ package io.komune.registry.s2.concept.domain.command
 
 import io.komune.registry.s2.commons.model.Language
 import io.komune.registry.s2.concept.domain.ConceptId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a concept.

--- a/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/DatasetAggregateService.kt
+++ b/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/DatasetAggregateService.kt
@@ -24,8 +24,8 @@ import io.komune.registry.s2.dataset.domain.command.DatasetUpdateCommand
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdateDistributionCommand
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdatedDistributionEvent
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdatedEvent
-import org.springframework.stereotype.Service
 import java.util.UUID
+import org.springframework.stereotype.Service
 
 @Service
 class DatasetAggregateService(

--- a/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/config/DatasetAutomateConfig.kt
+++ b/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/config/DatasetAutomateConfig.kt
@@ -22,10 +22,8 @@ class DatasetAutomateConfig(
 	aggregate,
 	evolver,
 	datasetSnapRepository,
-	"Dataset"
+	DatasetEntity::class
 ) {
-	override fun redisEntityType() = DatasetEntity::class
-
 	override fun automate() = s2Dataset
 	override fun entityType(): KClass<DatasetEvent> = DatasetEvent::class
 }

--- a/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/config/DatasetAutomateConfig.kt
+++ b/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/config/DatasetAutomateConfig.kt
@@ -1,6 +1,6 @@
 package io.komune.registry.program.s2.dataset.api.config
 
-import io.komune.registry.infra.postgresql.RegistryS2SourcingSpringDataAdapter
+import io.komune.registry.infra.redis.RegistryS2SourcingSpringDataAdapter
 import io.komune.registry.program.s2.dataset.api.DatasetEvolver
 import io.komune.registry.program.s2.dataset.api.entity.DatasetEntity
 import io.komune.registry.program.s2.dataset.api.entity.DatasetSnapRepository
@@ -24,6 +24,8 @@ class DatasetAutomateConfig(
 	datasetSnapRepository,
 	"Dataset"
 ) {
+	override fun redisEntityType() = DatasetEntity::class
+
 	override fun automate() = s2Dataset
 	override fun entityType(): KClass<DatasetEvent> = DatasetEvent::class
 }

--- a/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/config/DatasetAutomateConfig.kt
+++ b/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/config/DatasetAutomateConfig.kt
@@ -8,10 +8,10 @@ import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.dataset.domain.automate.DatasetState
 import io.komune.registry.s2.dataset.domain.automate.s2Dataset
 import io.komune.registry.s2.dataset.domain.command.DatasetEvent
+import kotlin.reflect.KClass
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import kotlin.reflect.KClass
 
 @Configuration
 class DatasetAutomateConfig(

--- a/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/entity/DatasetRepository.kt
+++ b/platform/data/s2/dataset/dataset-api/src/main/kotlin/io/komune/registry/program/s2/dataset/api/entity/DatasetRepository.kt
@@ -2,8 +2,8 @@ package io.komune.registry.program.s2.dataset.api.entity
 
 import io.komune.registry.infra.redis.RedisRepository
 import io.komune.registry.s2.commons.model.DatasetId
-import org.springframework.stereotype.Repository
 import java.util.Optional
+import org.springframework.stereotype.Repository
 
 @Repository
 interface DatasetRepository: RedisRepository<DatasetEntity, DatasetId> {

--- a/platform/data/s2/dataset/dataset-domain/src/commonMain/kotlin/io/komune/registry/s2/dataset/domain/automate/S2Dataset.kt
+++ b/platform/data/s2/dataset/dataset-domain/src/commonMain/kotlin/io/komune/registry/s2/dataset/domain/automate/S2Dataset.kt
@@ -22,11 +22,11 @@ import io.komune.registry.s2.dataset.domain.command.DatasetUpdateCommand
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdateDistributionCommand
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdatedDistributionEvent
 import io.komune.registry.s2.dataset.domain.command.DatasetUpdatedEvent
+import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Role
 import s2.dsl.automate.S2State
 import s2.dsl.automate.builder.s2Sourcing
-import kotlin.js.JsExport
 
 val s2Dataset = s2Sourcing {
     name = "Dataset"

--- a/platform/data/s2/dataset/dataset-domain/src/commonMain/kotlin/io/komune/registry/s2/dataset/domain/command/DatasetMessage.kt
+++ b/platform/data/s2/dataset/dataset-domain/src/commonMain/kotlin/io/komune/registry/s2/dataset/domain/command/DatasetMessage.kt
@@ -2,10 +2,10 @@ package io.komune.registry.s2.dataset.domain.command
 
 import io.komune.registry.s2.commons.model.DatasetId
 import io.komune.registry.s2.commons.model.S2SourcingEvent
+import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2InitCommand
-import kotlin.js.JsExport
 
 @JsExport
 @Serializable

--- a/platform/data/s2/license/license-api/src/main/kotlin/io/komune/registry/s2/license/api/LicenseAggregateService.kt
+++ b/platform/data/s2/license/license-api/src/main/kotlin/io/komune/registry/s2/license/api/LicenseAggregateService.kt
@@ -5,8 +5,8 @@ import io.komune.registry.s2.license.domain.command.LicenseCreateCommand
 import io.komune.registry.s2.license.domain.command.LicenseCreatedEvent
 import io.komune.registry.s2.license.domain.command.LicenseUpdateCommand
 import io.komune.registry.s2.license.domain.command.LicenseUpdatedEvent
-import org.springframework.stereotype.Service
 import java.util.UUID
+import org.springframework.stereotype.Service
 
 @Service
 class LicenseAggregateService(

--- a/platform/data/s2/license/license-api/src/main/kotlin/io/komune/registry/s2/license/api/entity/LicenseAutomateConfig.kt
+++ b/platform/data/s2/license/license-api/src/main/kotlin/io/komune/registry/s2/license/api/entity/LicenseAutomateConfig.kt
@@ -1,5 +1,6 @@
 package io.komune.registry.s2.license.api.entity
 
+import io.komune.registry.infra.redis.RegistryS2SourcingSpringDataAdapter
 import io.komune.registry.s2.license.api.LicenseEvolver
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.license.domain.LicenseState
@@ -11,11 +12,9 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import s2.spring.sourcing.data.S2SourcingSpringDataAdapter
 import kotlin.reflect.KClass
 
 @Configuration
@@ -23,29 +22,12 @@ class LicenseAutomateConfig(
     aggregate: LicenseAutomateExecutor,
     evolver: LicenseEvolver,
     projectSnapRepository: LicenseSnapRepository,
-    private val repository: LicenseRepository
-): S2SourcingSpringDataAdapter<LicenseEntity, LicenseState, LicenseEvent, LicenseId, LicenseAutomateExecutor>(
+): RegistryS2SourcingSpringDataAdapter<LicenseEntity, LicenseState, LicenseEvent, LicenseId, LicenseAutomateExecutor>(
 	aggregate,
 	evolver,
-	projectSnapRepository
+	projectSnapRepository,
+	LicenseEntity::class,
 ) {
-
-	private val logger = LoggerFactory.getLogger(LicenseAutomateConfig::class.java)
-	override fun afterPropertiesSet() {
-		super.afterPropertiesSet()
-		if (repository.count() == 0L) {
-			try {
-				runBlocking {
-					logger.info("/////////////////////////")
-					logger.info("Replay License history")
-					executor.replayHistory()
-					logger.info("/////////////////////////")
-				}
-			} catch (e: Exception) {
-				logger.error("Replay history error", e)
-			}
-		}
-	}
 
 	override fun automate() = s2License
 

--- a/platform/data/s2/license/license-api/src/main/kotlin/io/komune/registry/s2/license/api/entity/LicenseAutomateConfig.kt
+++ b/platform/data/s2/license/license-api/src/main/kotlin/io/komune/registry/s2/license/api/entity/LicenseAutomateConfig.kt
@@ -8,14 +8,13 @@ import io.komune.registry.s2.license.domain.command.LicenseCreatedEvent
 import io.komune.registry.s2.license.domain.command.LicenseEvent
 import io.komune.registry.s2.license.domain.command.LicenseUpdatedEvent
 import io.komune.registry.s2.license.domain.s2License
-import kotlinx.coroutines.runBlocking
+import kotlin.reflect.KClass
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Service
 import s2.spring.automate.sourcing.S2AutomateDeciderSpring
-import kotlin.reflect.KClass
 
 @Configuration
 class LicenseAutomateConfig(

--- a/platform/data/s2/license/license-domain/src/commonMain/kotlin/io/komune/registry/s2/license/domain/command/LicenseCreateCommand.kt
+++ b/platform/data/s2/license/license-domain/src/commonMain/kotlin/io/komune/registry/s2/license/domain/command/LicenseCreateCommand.kt
@@ -2,8 +2,8 @@ package io.komune.registry.s2.license.domain.command
 
 import io.komune.registry.s2.license.domain.LicenseId
 import io.komune.registry.s2.license.domain.LicenseIdentifier
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Create a license.

--- a/platform/data/s2/license/license-domain/src/commonMain/kotlin/io/komune/registry/s2/license/domain/command/LicenseMessage.kt
+++ b/platform/data/s2/license/license-domain/src/commonMain/kotlin/io/komune/registry/s2/license/domain/command/LicenseMessage.kt
@@ -2,9 +2,9 @@ package io.komune.registry.s2.license.domain.command
 
 import io.komune.registry.s2.commons.model.S2SourcingEvent
 import io.komune.registry.s2.license.domain.LicenseId
+import kotlin.js.JsExport
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2InitCommand
-import kotlin.js.JsExport
 
 @JsExport
 sealed interface LicenseEvent: S2SourcingEvent<LicenseId>

--- a/platform/data/s2/license/license-domain/src/commonMain/kotlin/io/komune/registry/s2/license/domain/command/LicenseUpdateCommand.kt
+++ b/platform/data/s2/license/license-domain/src/commonMain/kotlin/io/komune/registry/s2/license/domain/command/LicenseUpdateCommand.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.s2.license.domain.command
 
 import io.komune.registry.s2.license.domain.LicenseId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 /**
  * Update a license.

--- a/platform/data/test/src/main/kotlin/io/komune/registry/data/test/bdd/config/ImServiceMock.kt
+++ b/platform/data/test/src/main/kotlin/io/komune/registry/data/test/bdd/config/ImServiceMock.kt
@@ -2,8 +2,8 @@ package io.komune.registry.data.test.bdd.config
 
 import io.komune.im.f2.organization.domain.model.Organization
 import io.komune.registry.data.test.bdd.VerTestContext
-import io.komune.registry.s2.commons.exception.NotFoundException
 import io.komune.registry.infra.im.ImService
+import io.komune.registry.s2.commons.exception.NotFoundException
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 

--- a/platform/data/test/src/main/kotlin/io/komune/registry/data/test/bdd/f2/catalogue/command/CatalogueDeleteF2Steps.kt
+++ b/platform/data/test/src/main/kotlin/io/komune/registry/data/test/bdd/f2/catalogue/command/CatalogueDeleteF2Steps.kt
@@ -2,12 +2,12 @@ package io.komune.registry.data.test.bdd.f2.catalogue.command
 
 import f2.dsl.fnc.invokeWith
 import io.cucumber.java8.En
+import io.komune.registry.data.test.bdd.VerCucumberStepsDefinition
+import io.komune.registry.data.test.bdd.f2.catalogue.data.catalogue
 import io.komune.registry.f2.catalogue.api.CatalogueEndpoint
 import io.komune.registry.program.s2.catalogue.api.entity.CatalogueRepository
 import io.komune.registry.s2.catalogue.domain.automate.CatalogueState
 import io.komune.registry.s2.catalogue.domain.command.CatalogueDeleteCommand
-import io.komune.registry.data.test.bdd.VerCucumberStepsDefinition
-import io.komune.registry.data.test.bdd.f2.catalogue.data.catalogue
 import org.springframework.beans.factory.annotation.Autowired
 import s2.bdd.assertion.AssertionBdd
 import s2.bdd.data.TestContextKey

--- a/platform/data/test/src/main/kotlin/io/komune/registry/data/test/bdd/f2/dataset/command/DatasetLinkF2Steps.kt
+++ b/platform/data/test/src/main/kotlin/io/komune/registry/data/test/bdd/f2/dataset/command/DatasetLinkF2Steps.kt
@@ -14,11 +14,11 @@ import io.komune.registry.f2.dataset.domain.command.DatasetLinkThemesCommandDTOB
 import io.komune.registry.program.s2.dataset.api.entity.DatasetEntity
 import io.komune.registry.program.s2.dataset.api.entity.DatasetRepository
 import io.komune.registry.s2.commons.model.DatasetId
+import kotlin.jvm.optionals.getOrNull
 import org.assertj.core.api.Assertions
 import org.springframework.beans.factory.annotation.Autowired
 import s2.bdd.assertion.AssertionBdd
 import s2.bdd.data.TestContextKey
-import kotlin.jvm.optionals.getOrNull
 
 class DatasetLinkF2Steps: En, VerCucumberStepsDefinition() {
 

--- a/platform/identity/f2/organization-f2/organization-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/organization/domain/model/OrganizationRefDTO.kt
+++ b/platform/identity/f2/organization-f2/organization-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/organization/domain/model/OrganizationRefDTO.kt
@@ -1,8 +1,8 @@
 package io.komune.registry.f2.organization.domain.model
 
 import io.komune.registry.s2.commons.model.OrganizationId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @JsExport
 interface OrganizationRefDTO {

--- a/platform/identity/f2/user-f2/user-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/user/domain/model/UserRefDTO.kt
+++ b/platform/identity/f2/user-f2/user-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/user/domain/model/UserRefDTO.kt
@@ -2,8 +2,8 @@ package io.komune.registry.f2.user.domain.model
 
 import io.komune.registry.s2.commons.model.OrganizationId
 import io.komune.registry.s2.commons.model.UserId
-import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 @JsExport
 interface UserRefDTO {

--- a/platform/infra/im/src/main/kotlin/io/komune/registry/infra/im/ImConfiguration.kt
+++ b/platform/infra/im/src/main/kotlin/io/komune/registry/infra/im/ImConfiguration.kt
@@ -1,15 +1,7 @@
 package io.komune.registry.infra.im
 
-import f2.client.domain.AuthRealm
-import f2.client.ktor.F2ClientBuilder
-import f2.client.ktor.http.plugin.F2Auth
-import f2.dsl.fnc.F2SupplierSingle
-import f2.dsl.fnc.f2SupplierSingle
 import io.komune.im.f2.organization.client.OrganizationClient
 import io.komune.im.f2.organization.client.organizationClient
-import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logging
 import kotlinx.coroutines.runBlocking
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean

--- a/platform/infra/meilisearch/src/jvmMain/kotlin/io/komune/registry/infra/meilisearch/config/MeiliSearchSnapRepository.kt
+++ b/platform/infra/meilisearch/src/jvmMain/kotlin/io/komune/registry/infra/meilisearch/config/MeiliSearchSnapRepository.kt
@@ -4,12 +4,12 @@ import com.meilisearch.sdk.Client
 import com.meilisearch.sdk.Index
 import com.meilisearch.sdk.exceptions.MeilisearchApiException
 import com.meilisearch.sdk.model.Settings
-import org.springframework.beans.factory.InitializingBean
-import org.springframework.beans.factory.annotation.Autowired
-import s2.spring.utils.logger.Logger
 import kotlin.reflect.KClass
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.beans.factory.annotation.Autowired
+import s2.spring.utils.logger.Logger
 
 abstract class MeiliSearchSnapRepository<Entity: Any>(
     protected val indexName: String,

--- a/platform/infra/meilisearch/src/jvmMain/kotlin/io/komune/registry/infra/meilisearch/config/MeiliSearchSnapRepository.kt
+++ b/platform/infra/meilisearch/src/jvmMain/kotlin/io/komune/registry/infra/meilisearch/config/MeiliSearchSnapRepository.kt
@@ -8,6 +8,8 @@ import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.annotation.Autowired
 import s2.spring.utils.logger.Logger
 import kotlin.reflect.KClass
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 abstract class MeiliSearchSnapRepository<Entity: Any>(
     protected val indexName: String,
@@ -38,8 +40,8 @@ abstract class MeiliSearchSnapRepository<Entity: Any>(
         }
     }
 
-    open suspend fun get(id: String): Entity? {
-        return try {
+    open suspend fun get(id: String): Entity? = withContext(Dispatchers.IO) {
+        try {
             index.getDocument(id, entityClass.java)
         } catch (e: MeilisearchApiException) {
             if (e.code == "document_not_found") {
@@ -55,8 +57,8 @@ abstract class MeiliSearchSnapRepository<Entity: Any>(
         }
     }
 
-    open suspend fun remove(id: String): Boolean {
-        return try {
+    open suspend fun remove(id: String): Boolean = withContext(Dispatchers.IO) {
+        try {
             index.deleteDocument(id)
             true
         } catch (e: Exception) {

--- a/platform/infra/redis/build.gradle.kts
+++ b/platform/infra/redis/build.gradle.kts
@@ -9,4 +9,5 @@ dependencies {
 	implementation(project(":platform:commons"))
 
 	Dependencies.Jvm.redisOm(::api, ::kapt)
+	Dependencies.Jvm.s2Sourcing(::implementation)
 }

--- a/platform/infra/redis/src/main/kotlin/io/komune/registry/infra/redis/RegistryS2SourcingSpringDataAdapter.kt
+++ b/platform/infra/redis/src/main/kotlin/io/komune/registry/infra/redis/RegistryS2SourcingSpringDataAdapter.kt
@@ -23,7 +23,7 @@ abstract class RegistryS2SourcingSpringDataAdapter<ENTITY, STATE, EVENT, ID, EXE
 	aggregate: EXECUTOR,
 	evolver: View<EVENT, ENTITY>,
 	projectSnapRepository: SnapRepository<ENTITY, ID>,
-	protected val entityName: String
+	private val redisEntityType: KClass<ENTITY>
 ) : S2SourcingSpringDataAdapter<ENTITY, STATE, EVENT, ID, EXECUTOR>(
 	aggregate,
 	evolver,
@@ -44,13 +44,13 @@ EXECUTOR : S2AutomateDeciderSpring<ENTITY, STATE, EVENT, ID>
 
 	override fun afterPropertiesSet() {
 		super.afterPropertiesSet()
-		val entityType = redisEntityType().java
+		val entityType = redisEntityType.java
 		val count = entityStream.of(entityType).count()
 		if (count == 0L) {
 			try {
 				runBlocking {
 					logger.info("/////////////////////////")
-					logger.info("Replay $entityName history")
+					logger.info("Replay ${entityType.name} history")
 					executor.replayHistory()
 					logger.info("/////////////////////////")
 				}
@@ -59,8 +59,6 @@ EXECUTOR : S2AutomateDeciderSpring<ENTITY, STATE, EVENT, ID>
 			}
 		}
 	}
-
-	abstract fun redisEntityType(): KClass<ENTITY>
 
 	override fun json(): Json = Json {
 		serializersModule = SerializersModule {

--- a/platform/project/f2/asset-order-f2/asset-order-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/asset/order/domain/command/AssetOrderCancelCommandDTO.kt
+++ b/platform/project/f2/asset-order-f2/asset-order-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/asset/order/domain/command/AssetOrderCancelCommandDTO.kt
@@ -2,7 +2,6 @@ package io.komune.registry.f2.asset.order.domain.command
 
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.order.domain.OrderId
-import io.komune.registry.s2.order.domain.command.OrderCancelCommand
 import kotlin.js.JsExport
 
 /**

--- a/platform/project/s2/asset/asset-api/src/main/kotlin/io/komune/registry/s2/asset/api/AssetPoolAggregateService.kt
+++ b/platform/project/s2/asset/asset-api/src/main/kotlin/io/komune/registry/s2/asset/api/AssetPoolAggregateService.kt
@@ -30,8 +30,8 @@ import io.komune.registry.s2.asset.domain.command.transaction.AssetTransactionEm
 import io.komune.registry.s2.asset.domain.command.transaction.TransactionEmittedEvent
 import io.komune.registry.s2.asset.domain.model.AssetTransactionType
 import io.komune.registry.s2.commons.model.respectsGranularity
-import org.springframework.stereotype.Service
 import java.util.UUID
+import org.springframework.stereotype.Service
 
 @Service
 class AssetPoolAggregateService(

--- a/platform/project/s2/asset/asset-api/src/main/kotlin/io/komune/registry/s2/asset/api/AssetPoolFinderService.kt
+++ b/platform/project/s2/asset/asset-api/src/main/kotlin/io/komune/registry/s2/asset/api/AssetPoolFinderService.kt
@@ -4,7 +4,6 @@ import f2.dsl.cqrs.filter.Match
 import f2.dsl.cqrs.page.OffsetPagination
 import f2.dsl.cqrs.page.PageDTO
 import f2.dsl.cqrs.page.map
-import io.komune.registry.s2.commons.exception.NotFoundException
 import io.komune.registry.s2.asset.api.entity.pool.AssetPoolEntity
 import io.komune.registry.s2.asset.api.entity.pool.AssetPoolRepository
 import io.komune.registry.s2.asset.api.entity.pool.toAssetPool
@@ -20,6 +19,7 @@ import io.komune.registry.s2.asset.domain.automate.AssetTransactionId
 import io.komune.registry.s2.asset.domain.model.AssetPool
 import io.komune.registry.s2.asset.domain.model.AssetTransaction
 import io.komune.registry.s2.asset.domain.model.AssetTransactionType
+import io.komune.registry.s2.commons.exception.NotFoundException
 import org.springframework.stereotype.Service
 
 @Service

--- a/platform/project/s2/asset/asset-domain/src/commonMain/kotlin/io/komune/registry/s2/asset/domain/model/AssetPool.kt
+++ b/platform/project/s2/asset/asset-domain/src/commonMain/kotlin/io/komune/registry/s2/asset/domain/model/AssetPool.kt
@@ -3,7 +3,6 @@ package io.komune.registry.s2.asset.domain.model
 import cccev.dsl.model.InformationConcept
 import io.komune.registry.s2.asset.domain.automate.AssetPoolId
 import io.komune.registry.s2.asset.domain.automate.AssetPoolState
-import io.komune.registry.s2.asset.domain.command.pool.InformationConceptIdentifier
 import io.komune.registry.s2.commons.model.BigDecimalAsString
 import kotlin.js.JsExport
 import kotlinx.serialization.Serializable

--- a/platform/project/s2/order/order-domain/src/commonMain/kotlin/io/komune/registry/s2/order/domain/S2Order.kt
+++ b/platform/project/s2/order/order-domain/src/commonMain/kotlin/io/komune/registry/s2/order/domain/S2Order.kt
@@ -15,14 +15,14 @@ import io.komune.registry.s2.order.domain.command.OrderSubmitCommand
 import io.komune.registry.s2.order.domain.command.OrderSubmittedEvent
 import io.komune.registry.s2.order.domain.command.OrderUpdateCommand
 import io.komune.registry.s2.order.domain.command.OrderUpdatedEvent
+import kotlin.js.JsExport
+import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2InitCommand
 import s2.dsl.automate.S2Role
 import s2.dsl.automate.S2State
 import s2.dsl.automate.builder.s2Sourcing
-import kotlin.js.JsExport
-import kotlin.js.JsName
 
 val s2Order = s2Sourcing {
     name = "OrderS2"

--- a/platform/project/s2/order/order-domain/src/commonMain/kotlin/io/komune/registry/s2/order/domain/command/OrderCancelCommand.kt
+++ b/platform/project/s2/order/order-domain/src/commonMain/kotlin/io/komune/registry/s2/order/domain/command/OrderCancelCommand.kt
@@ -3,7 +3,6 @@ package io.komune.registry.s2.order.domain.command
 import io.komune.registry.s2.order.domain.OrderCommand
 import io.komune.registry.s2.order.domain.OrderEvent
 import io.komune.registry.s2.order.domain.OrderId
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 data class OrderCancelCommand(

--- a/platform/project/s2/order/order-domain/src/jvmTest/kotlin/S2OrderTest.kt
+++ b/platform/project/s2/order/order-domain/src/jvmTest/kotlin/S2OrderTest.kt
@@ -1,7 +1,7 @@
+import io.komune.registry.s2.order.domain.s2Order
 import org.junit.jupiter.api.Test
 import s2.automate.documenter.S2Documenter
 import s2.automate.documenter.writeS2Automate
-import io.komune.registry.s2.order.domain.s2Order
 
 class S2OrderTest {
 

--- a/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/config/ImServiceMock.kt
+++ b/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/config/ImServiceMock.kt
@@ -1,9 +1,9 @@
 package io.komune.registry.project.test.bdd.config
 
 import io.komune.im.f2.organization.domain.model.Organization
-import io.komune.registry.s2.commons.exception.NotFoundException
 import io.komune.registry.infra.im.ImService
 import io.komune.registry.project.test.bdd.VerTestContext
+import io.komune.registry.s2.commons.exception.NotFoundException
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Service
 

--- a/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/f2/asset/command/AssetOrderF2Steps.kt
+++ b/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/f2/asset/command/AssetOrderF2Steps.kt
@@ -9,11 +9,11 @@ import io.komune.registry.f2.asset.order.domain.query.AssetOrderGetQueryDTOBase
 import io.komune.registry.f2.asset.order.domain.query.AssetOrderGetResultDTOBase
 import io.komune.registry.f2.asset.order.domain.query.AssetOrderPageQueryDTOBase
 import io.komune.registry.f2.asset.order.domain.query.AssetOrderPageResult
+import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
 import io.komune.registry.s2.asset.domain.automate.AssetPoolId
 import io.komune.registry.s2.asset.domain.model.AssetTransactionType
 import io.komune.registry.s2.commons.model.BigDecimalAsString
 import io.komune.registry.s2.order.domain.OrderId
-import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
 import org.assertj.core.api.Assertions
 import org.springframework.beans.factory.annotation.Autowired
 import s2.bdd.data.TestContextKey

--- a/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/asset/command/AssetPoolCreateSteps.kt
+++ b/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/asset/command/AssetPoolCreateSteps.kt
@@ -2,13 +2,13 @@ package io.komune.registry.project.test.bdd.s2.asset.command
 
 import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
+import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
+import io.komune.registry.project.test.bdd.concept.informationConceptTest
+import io.komune.registry.project.test.bdd.s2.asset.data.assetPool
 import io.komune.registry.s2.asset.api.AssetPoolAggregateService
 import io.komune.registry.s2.asset.api.entity.pool.AssetPoolRepository
 import io.komune.registry.s2.asset.domain.automate.AssetPoolState
 import io.komune.registry.s2.asset.domain.command.pool.AssetPoolCreateCommand
-import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
-import io.komune.registry.project.test.bdd.concept.informationConceptTest
-import io.komune.registry.project.test.bdd.s2.asset.data.assetPool
 import kotlin.jvm.optionals.getOrNull
 import org.assertj.core.api.Assertions
 import org.springframework.beans.factory.annotation.Autowired

--- a/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/asset/command/AssetPoolEmitTransactionSteps.kt
+++ b/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/asset/command/AssetPoolEmitTransactionSteps.kt
@@ -4,14 +4,14 @@ import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
+import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
+import io.komune.registry.project.test.bdd.s2.asset.data.assetPool
+import io.komune.registry.project.test.bdd.s2.asset.data.transaction
 import io.komune.registry.s2.asset.api.AssetPoolAggregateService
 import io.komune.registry.s2.asset.api.entity.pool.AssetPoolRepository
 import io.komune.registry.s2.asset.api.entity.transaction.AssetTransactionRepository
 import io.komune.registry.s2.asset.domain.command.pool.AssetPoolEmitTransactionCommand
 import io.komune.registry.s2.asset.domain.model.AssetTransactionType
-import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
-import io.komune.registry.project.test.bdd.s2.asset.data.assetPool
-import io.komune.registry.project.test.bdd.s2.asset.data.transaction
 import kotlin.jvm.optionals.getOrNull
 import org.assertj.core.api.Assertions
 import org.springframework.beans.factory.annotation.Autowired

--- a/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/project/command/ProjectCreateSteps.kt
+++ b/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/project/command/ProjectCreateSteps.kt
@@ -2,6 +2,7 @@ package io.komune.registry.project.test.bdd.s2.project.command
 
 import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
+import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
 import io.komune.registry.s2.commons.model.GeoLocation
 import io.komune.registry.s2.project.api.ProjectAggregateService
 import io.komune.registry.s2.project.api.entity.ProjectRepository
@@ -9,7 +10,6 @@ import io.komune.registry.s2.project.domain.command.ProjectCreateCommand
 import io.komune.registry.s2.project.domain.model.DateTime
 import io.komune.registry.s2.project.domain.model.OrganizationRef
 import io.komune.registry.s2.project.domain.model.SdgNumber
-import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 import org.assertj.core.api.Assertions

--- a/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/project/command/ProjectUpdateSteps.kt
+++ b/platform/project/test/src/main/kotlin/io/komune/registry/project/test/bdd/s2/project/command/ProjectUpdateSteps.kt
@@ -3,6 +3,7 @@ package io.komune.registry.project.test.bdd.s2.project.command
 import cccev.dsl.model.InformationConceptIdentifier
 import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
+import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
 import io.komune.registry.s2.commons.model.GeoLocation
 import io.komune.registry.s2.project.api.ProjectAggregateService
 import io.komune.registry.s2.project.api.entity.ProjectRepository
@@ -13,7 +14,6 @@ import io.komune.registry.s2.project.domain.model.ActivityIdentifier
 import io.komune.registry.s2.project.domain.model.DateTime
 import io.komune.registry.s2.project.domain.model.OrganizationRef
 import io.komune.registry.s2.project.domain.model.SdgNumber
-import io.komune.registry.project.test.bdd.VerCucumberStepsDefinition
 import kotlin.jvm.optionals.getOrNull
 import org.assertj.core.api.Assertions
 import org.springframework.beans.factory.annotation.Autowired

--- a/platform/web/packages/domain/src/Catalogue/api/query.ts
+++ b/platform/web/packages/domain/src/Catalogue/api/query.ts
@@ -128,7 +128,7 @@ export const useLexicalDownloadDistribution = (catalogue?: Catalogue) => {
     return findLexicalDataset(catalogue)
   }, [catalogue])
 
-  const query = useDownloadDistribution<any>("json", dataSet?.dataSet.id, dataSet?.distribution.id)
+  const query = useDownloadDistribution<any>("text", dataSet?.dataSet.id, dataSet?.distribution.id)
 
   return {
     query,


### PR DESCRIPTION
The download distribution format is updated to "text" to match the expected format from the API. This change ensures that the application correctly handles the data format returned by the API, preventing potential errors in data processing.