### PR TITLE
refactor(ImService.kt): change imClient injection from constructor to…

### DIFF
--- a/platform/infra/im/src/main/kotlin/io/komune/registry/infra/im/ImService.kt
+++ b/platform/infra/im/src/main/kotlin/io/komune/registry/infra/im/ImService.kt
@@ -25,9 +25,10 @@ import org.springframework.stereotype.Service
 typealias OrganizationName = String
 
 @Service
-class ImService(
-    var imClient: ImClient,
-) {
+class ImService {
+
+    @Autowired
+    private lateinit  var imClient: ImClient
 
     private val organizationNameCache = SimpleCache<OrganizationName, OrganizationId?> { name ->
         OrganizationPageQuery(


### PR DESCRIPTION
… field injection for better flexibility

The imClient is now injected using the @Autowired annotation instead of being passed through the constructor. This change allows for more flexibility in the service's instantiation and aligns with Spring's preferred dependency injection practices.