### PR TITLE
Correct Registry Path Handling and Add Translations for Email Forgot Title

### DIFF
--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportScript.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportScript.kt
@@ -280,7 +280,7 @@ class ImportScript(
         file: File
     ) {
         val registryPath = properties.registry?.path?.let {
-            if (!it.endsWith("/")) "$it/" else it
+            if (it.endsWith("/")) it else "$it/"
         } ?: "/"
         val rawText = file.readText()
 

--- a/platform/web/packages/keycloak/src/login/i18n.ts
+++ b/platform/web/packages/keycloak/src/login/i18n.ts
@@ -7,6 +7,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
     .withThemeName<ThemeName>()
     .withCustomTranslations({
         en: {
+            emailForgotTitle: "Reset your password ?",
             alphanumericalCharsOnly: "Only alphanumerical characters",
             gender: "Gender",
             doForgotPassword: "Forgot password ?",
@@ -42,6 +43,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             loginTotpScanBarcode: "Scan a qr code instead"
         },
         fr: {
+            emailForgotTitle: "Réinitialisation de votre mot de passe ?",
             alphanumericalCharsOnly: "Caractère alphanumérique uniquement:",
             gender: "Genre",
             doForgotPassword: "Mot de passe oublié ?",
@@ -77,6 +79,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             loginTotpScanBarcode: "Scanner un qr code à la place"
         },
         es: {
+            emailForgotTitle: "¿Restablecer la contraseña?",
             alphanumericalCharsOnly: "Solo caracteres alfanuméricos",
             gender: "Género",
             doForgotPassword: "¿Olvidaste tu contraseña?",


### PR DESCRIPTION
Ensure registry path handling always ends with a slash to prevent potential issues with path concatenation.
Add translations for the "Reset your password?" title in English, French, and Spanish to enhance user experience and accessibility.