### PR TITLE
fix(application.yml): update init source path to use the correct directory for imports

### DIFF
--- a/platform/script/script-gateway/src/main/resources/application.yml
+++ b/platform/script/script-gateway/src/main/resources/application.yml
@@ -11,7 +11,7 @@ registry:
       max: 1
       delayMillis: 10000
     init:
-      source: ./import/fiches_dev_v2
+      source: ./import/fiches
       auth:
         realmId: registry-local
         url: http://im-keycloak:8080


### PR DESCRIPTION
The init source path is changed from `./import/fiches_dev_v2` to `./import/fiches` to ensure the application points to the correct directory for importing necessary files. This change resolves issues related to file access and improves the application's ability to load the required resources.