### PR TITLE
refactor(ImportScript.kt): rename lambda parameter for clarity in dataset mapping

### DIFF
--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportScript.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportScript.kt
@@ -165,8 +165,8 @@ class ImportScript(
         val fixedData = jsonFile.loadJsonCatalogue(importContext)
         val catalogues = importCatalogue(fixedData, importContext).forEach { catalogue ->
             logger.info("Imported catalogue[id:${catalogue.id}, identifier: ${catalogue.identifier}] ${catalogue.title}.")
-            importContext.settings.datasets?.map { it ->
-                importDataset(catalogue, it, jsonFile.parentFile)
+            importContext.settings.datasets?.map { dataset ->
+                importDataset(catalogue, dataset, jsonFile.parentFile)
             }
         }
     }


### PR DESCRIPTION
Improves code readability by changing the lambda parameter name from `it` to `dataset`. This makes it clearer what the parameter represents, enhancing maintainability and understanding of the code.