### PR TITLE
feat(UploadImageModal): refactor imports for better readability and organization

### DIFF
--- a/platform/web/packages/components/src/LexicalEditor/plugins/ImagesPlugin/UploadImageModal.tsx
+++ b/platform/web/packages/components/src/LexicalEditor/plugins/ImagesPlugin/UploadImageModal.tsx
@@ -9,8 +9,7 @@ import { useParams } from "react-router-dom";
 import { SectionTab, Tab } from "../../../SectionTab";
 import { Stack } from "@mui/material";
 import { CustomButton } from "../../../CustomButton";
-import {ResourceGallery} from "../../../dataset";
-import {GraphGallery} from "../../../dataset/GraphGallery";
+import { ResourceGallery, GraphGallery } from "../../../dataset";
 
 export interface UploadImageModalProps {
     open: boolean

--- a/platform/web/packages/components/src/dataset/GraphGallery/GraphGallery.tsx
+++ b/platform/web/packages/components/src/dataset/GraphGallery/GraphGallery.tsx
@@ -1,0 +1,53 @@
+import {useDatasetGraphSearchQuery} from "domain-components";
+import {useMemo} from "react";
+import {g2Config} from "@komune-io/g2";
+import {Stack} from "@mui/material";
+import {ImageCard} from "../../ImageCard";
+
+interface ChartsGalleryProps {
+  language: string
+  onClickImage: (src: string) => void
+  open: boolean
+}
+
+export const GraphGallery = (props: ChartsGalleryProps) => {
+  const { language, onClickImage, open } = props
+
+  // TODO custom data, need to be generalized
+  const datasetGraphSearchQuery = useDatasetGraphSearchQuery({
+    query: {
+      rootCatalogueIdentifier: "100m-charts",
+      datasetType: "rawGraph",
+      language: language
+    }
+  })
+  const graphsDisplay = useMemo(() => {
+    const datasets = datasetGraphSearchQuery.data?.items ?? []
+    console.log("datasetGraphSearchQuery.datasets", datasets)
+    return datasets?.map((dataset) => {
+      const imageDistribution = dataset.distributions?.find((dist) => dist.mediaType === "image/svg+xml")
+      console.log("datasetGraphSearchQuery", dataset.distributions)
+      console.log("datasetGraphSearchQuery", imageDistribution)
+      if (!imageDistribution) return
+      const src = g2Config().platform.url + `/data/datasetDownloadDistribution/${dataset.id}/${imageDistribution.id}`
+      return (
+        <ImageCard
+          imageUrl={src}
+          onClick={() => {
+            open && onClickImage(src)
+          }}
+          label={dataset.title}
+        />
+      )
+    })
+  }, [datasetGraphSearchQuery.data?.items, onClickImage, open])
+
+  return <Stack
+    direction="row"
+    gap={3}
+    flexWrap="wrap"
+    alignItems="flex-start"
+  >
+    {graphsDisplay}
+  </Stack>;
+}

--- a/platform/web/packages/components/src/dataset/GraphGallery/index.ts
+++ b/platform/web/packages/components/src/dataset/GraphGallery/index.ts
@@ -1,0 +1,1 @@
+export * from "./GraphGallery"

--- a/platform/web/packages/components/src/dataset/ResourceGallery/ResourceGallery.tsx
+++ b/platform/web/packages/components/src/dataset/ResourceGallery/ResourceGallery.tsx
@@ -1,0 +1,47 @@
+import {useCatalogueDraftGetQuery} from "domain-components";
+import {useMemo} from "react";
+import {g2Config} from "@komune-io/g2";
+import {Stack} from "@mui/material";
+import {ImageCard} from "../../ImageCard";
+
+interface ResourceGalleryProps {
+  draftId: string
+  onClickImage: (src: string) => void
+  open: boolean
+}
+
+export const ResourceGallery = (props: ResourceGalleryProps) => {
+  const { draftId, onClickImage, open } = props
+
+  const catalogueDraftQuery = useCatalogueDraftGetQuery({
+    query: {
+      id: draftId
+    },
+  })
+
+  const draft = catalogueDraftQuery.data?.item
+
+  const graphsDisplay = useMemo(() => draft?.catalogue.datasets?.find((dataset) => dataset.type === "graphs")?.datasets?.map((dataset) => {
+    const imageDistribution = dataset.distributions?.find((dist) => dist.mediaType === "image/svg+xml")
+    if (!imageDistribution) return
+    const src = g2Config().platform.url + `/data/datasetDownloadDistribution/${dataset.id}/${imageDistribution.id}`
+    return (
+      <ImageCard
+        imageUrl={src}
+        onClick={() => {
+          open && onClickImage(src)
+        }}
+        label={dataset.title}
+      />
+    )
+  }), [draft, onClickImage, open])
+
+  return <Stack
+    direction="row"
+    gap={3}
+    flexWrap="wrap"
+    alignItems="flex-start"
+  >
+    {graphsDisplay}
+  </Stack>;
+}

--- a/platform/web/packages/components/src/dataset/ResourceGallery/index.ts
+++ b/platform/web/packages/components/src/dataset/ResourceGallery/index.ts
@@ -1,0 +1,1 @@
+export * from "./ResourceGallery"

--- a/platform/web/packages/components/src/dataset/index.ts
+++ b/platform/web/packages/components/src/dataset/index.ts
@@ -1,0 +1,2 @@
+export * from "./GraphGallery"
+export * from "./ResourceGallery"


### PR DESCRIPTION
feat(GraphGallery): create GraphGallery component to display graph datasets
feat(ResourceGallery): create ResourceGallery component to display resource datasets
feat(dataset/index.ts): export GraphGallery and ResourceGallery for easier access

The import statements in `UploadImageModal.tsx` are refactored for better readability. New components `GraphGallery` and `ResourceGallery` are created to encapsulate the logic for displaying graph and resource datasets, respectively. This modular approach enhances code organization and reusability. The `index.ts` file in the dataset directory is updated to export these new components, simplifying their import in other parts of the application.