### PR TITLE
feat(InformationConceptCreateCommandDTO): add @Serializable annotatio…

### DIFF
--- a/platform/data/f2/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/cccev/domain/concept/command/InformationConceptCreateCommandDTO.kt
+++ b/platform/data/f2/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/cccev/domain/concept/command/InformationConceptCreateCommandDTO.kt
@@ -3,6 +3,7 @@ package io.komune.registry.f2.cccev.domain.concept.command
 import f2.dsl.fnc.F2Function
 import io.komune.registry.s2.commons.model.InformationConceptId
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
 typealias InformationConceptCreateFunction = F2Function<InformationConceptCreateCommandDTOBase, InformationConceptCreatedEventDTOBase>
 
@@ -16,6 +17,7 @@ interface InformationConceptCreatedEventDTO {
     val id: InformationConceptId
 }
 
+@Serializable
 data class InformationConceptCreatedEventDTOBase(
     override val id: InformationConceptId
 ) : InformationConceptCreatedEventDTO


### PR DESCRIPTION
…n to InformationConceptCreatedEventDTOBase for serialization support

The addition of the @Serializable annotation enables the serialization of the InformationConceptCreatedEventDTOBase data class, allowing it to be easily converted to and from various formats such as JSON. This change enhances the interoperability of the data class with external systems and improves data handling capabilities.