### PR TITLE
style(logging): change logger level from info to debug for detailed logging

### DIFF
--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportRepository.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportRepository.kt
@@ -158,7 +158,7 @@ class ImportRepository(
         }
 
         val title = dataset.title?.get(language)
-        logger.info("Creating dataset[$identifierLocalized] $title")
+        logger.debug("Creating dataset[$identifierLocalized] $title")
 
         val created = DatasetCreateCommandDTOBase(
             identifier = identifierLocalized,
@@ -185,7 +185,7 @@ class ImportRepository(
         mediaType: String,
         file: SimpleFile,
     ): DistributionId {
-        logger.info("Creating distribution[${dataset.id}] ${file.name} ${mediaType}")
+        logger.debug("Creating distribution[${dataset.id}] ${file.name} ${mediaType}")
         // Basic filtering to avoid creating duplicate distributions
         val existingDistribution = dataset.distributions?.find {
             it.mediaType == mediaType

--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/MarkdownMediaImport.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/MarkdownMediaImport.kt
@@ -45,7 +45,7 @@ class MarkdownMediaImport(
                 val objectId = catalogueLinkMatch.groupValues[2]
                 val url = "${registryWebPath}catalogues/100m-${objectType}-$objectId/"
                 matchedPathToActualPath[path] = url
-                logger.info("Catalogue[$path] replace by: $url")
+                logger.debug("Catalogue[$path] replace by: $url")
                 modifiedText = modifiedText.replace(linkMatch.value, "[$title](${matchedPathToActualPath[path]})")
             }
         }
@@ -66,7 +66,7 @@ class MarkdownMediaImport(
                 val match = regex.find(path)?.groupValues?.get(1)?.toInt()
                 rawGraphPath[match]?.let {
                     val url = "${registryApiPath}${it}"
-                    logger.info("Path[$path] replace by: $url")
+                    logger.debug("Path[$path] replace by: $url")
                     matchedPathToActualPath[path] = url
                 }
             } else if (path !in matchedPathToActualPath) {
@@ -86,7 +86,7 @@ class MarkdownMediaImport(
                     file = resourceFile.toSimpleFile()
                 )
                 val url = "${registryApiPath}data/datasetDownloadDistribution/${resourcesDataset.id}/$distributionId"
-                logger.info("Path[$path] replace by: $url")
+                logger.debug("Path[$path] replace by: $url")
                 matchedPathToActualPath[path] = url
             }
 


### PR DESCRIPTION
The logging level for several messages is changed from info to debug to reduce log verbosity and ensure that only essential information is logged at the info level. This helps in maintaining cleaner logs while still allowing detailed tracing during debugging sessions.