### PR TITLE
feat(CatalogueSearchFinderService): handle empty search results by returning an empty item list

### DIFF
--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CatalogueSearchFinderService.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CatalogueSearchFinderService.kt
@@ -101,6 +101,13 @@ class CatalogueSearchFinderService(
             page = page
         )
 
+        if(result.items.isEmpty()) {
+            return@withCache CatalogueSearchResult(
+                items = emptyList(),
+                total = result.total,
+                distribution = result.distribution,
+            )
+        }
 
         val translatedCatalogues = catalogueF2FinderService.page(
             id = CollectionMatch(result.items.map { it.isTranslationOf!! }),


### PR DESCRIPTION
The service now checks if the search result items are empty and returns a `CatalogueSearchResult` with an empty list of items. This change improves the API's behavior by providing a clear response when no items are found, enhancing the user experience and preventing potential errors in downstream processing.