### PR TITLE
feat(config): add logging for loading type configurations in CatalogueConfig and DatasetConfig classes

### DIFF
--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/config/CatalogueConfig.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/config/CatalogueConfig.kt
@@ -14,9 +14,11 @@ class CatalogueConfig {
     private lateinit var typeConfigDir: String
 
     final val typeConfigurations: Map<String, CatalogueTypeConfiguration> by lazy {
+        logger.info("Loading catalogue type configurations from $typeConfigDir")
         PathMatchingResourcePatternResolver()
             .getResources("$typeConfigDir/*.json")
             .associate { file ->
+                logger.info("Loading catalogue type configuration ${file.url}")
                 val typeConfiguration = try {
                     jsonMapper.readValue(file.inputStream, CatalogueTypeConfiguration::class.java)
                 } catch (e: Exception) {

--- a/platform/data/f2/dataset-f2/dataset-f2-api/src/main/kotlin/io/komune/registry/f2/dataset/api/config/DatasetConfig.kt
+++ b/platform/data/f2/dataset-f2/dataset-f2-api/src/main/kotlin/io/komune/registry/f2/dataset/api/config/DatasetConfig.kt
@@ -14,9 +14,11 @@ class DatasetConfig {
     private lateinit var typeConfigDir: String
 
     final val typeConfigurations: Map<String, DatasetTypeConfiguration> by lazy {
+        logger.info("Loading dataset type configurations from $typeConfigDir")
         PathMatchingResourcePatternResolver()
             .getResources("$typeConfigDir/*.json")
             .associate { file ->
+                logger.info("Loading dataset type configuration from ${file.url}")
                 val typeConfiguration = try {
                     jsonMapper.readValue(file.inputStream, DatasetTypeConfiguration::class.java)
                 } catch (e: Exception) {


### PR DESCRIPTION
The changes introduce logging statements that provide visibility into the loading process of type configurations. This helps in debugging and monitoring by informing developers when configurations are being loaded and from which files, enhancing traceability in the application.