### PR TITLE
feat(DCatGraphClient): add new fields to CatalogueDTOBase for enhanced data handling

### DIFF
--- a/platform/data/dsl/client/src/jvmMain/kotlin/cccev/dsl/client/DCatGraphClient.kt
+++ b/platform/data/dsl/client/src/jvmMain/kotlin/cccev/dsl/client/DCatGraphClient.kt
@@ -264,8 +264,17 @@ fun CatalogueDTOBase.toUpdateCommand() = CatalogueUpdateCommandDTOBase(
     language = language,
     structure = structure,
     homepage = homepage,
-    themes = themes?.map { it.id },
+    themes = themes.map { it.id },
     accessRights = accessRights,
     license = license?.id,
-    hidden = hidden
+    location = location,
+    stakeholder = stakeholder,
+    integrateCounter = integrateCounter,
+    parentId = parent?.id,
+    versionNotes = versionNotes,
+    ownerOrganizationId = ownerOrganization?.id,
+    relatedCatalogueIds = relatedCatalogues
+        ?.map { it.key to it.value.map { catalogue -> catalogue.id } }
+        ?.toMap(),
+    hidden = hidden,
 )

--- a/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseListQueryDTO.kt
+++ b/platform/data/f2/license-f2/license-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/license/domain/query/LicenseListQueryDTO.kt
@@ -42,6 +42,7 @@ interface LicenseListResultDTO {
 /**
  * @d2 inherit
  */
+@Serializable
 data class LicenseListResult(
     override val items: List<LicenseDTOBase>
 ) : LicenseListResultDTO

--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportRepository.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/ImportRepository.kt
@@ -21,6 +21,7 @@ import io.komune.registry.f2.dataset.domain.query.DatasetGetQuery
 import io.komune.registry.f2.dataset.domain.query.DatasetGraphSearchQuery
 import io.komune.registry.f2.dataset.domain.query.DatasetPageQuery
 import io.komune.registry.f2.license.domain.query.LicenseGetByIdentifierQuery
+import io.komune.registry.f2.license.domain.query.LicenseListQuery
 import io.komune.registry.s2.cccev.domain.command.concept.InformationConceptCreateCommand
 import io.komune.registry.s2.cccev.domain.model.AggregatorConfig
 import io.komune.registry.s2.cccev.domain.model.CompositeDataUnitModel
@@ -76,6 +77,16 @@ class ImportRepository(
             }
             offset += limit
         } while (result.total > offset)
+    }
+
+    suspend fun fetchPreExistingLicence() {
+        val licenses = LicenseListQuery()
+            .invokeWith(dataClient.license.licenseList())
+            .items
+
+        licenses.forEach {
+            importContext.licenses[it.identifier] = it.id
+        }
     }
 
     suspend fun getOrCreateConcept(concept: ConceptInitData) = ConceptGetByIdentifierQuery(concept.identifier)

--- a/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/model/CatalogueImportData.kt
+++ b/platform/script/script-import/src/main/kotlin/io/komune/registry/script/imports/model/CatalogueImportData.kt
@@ -6,6 +6,7 @@ import io.komune.registry.s2.catalogue.domain.model.CatalogueAccessRight
 import io.komune.registry.s2.commons.model.CatalogueId
 import io.komune.registry.s2.commons.model.CatalogueIdentifier
 import io.komune.registry.s2.commons.model.Language
+import io.komune.registry.s2.commons.model.Location
 import io.komune.registry.s2.concept.domain.ConceptIdentifier
 import io.komune.registry.s2.structure.domain.model.Structure
 import io.komune.registry.script.imports.ImportContext
@@ -38,8 +39,10 @@ data class CatalogueTranslationData(
     val title: String?,
     val description: String?,
     val language: Language,
+    val stakeholder: String? = null,
+    val location: Location? = null,
 
-)
+    )
 
 fun File.loadJsonCatalogue(
     context: ImportContext


### PR DESCRIPTION
feat(ImportRepository): implement fetchPreExistingLicence to retrieve existing licenses feat(ImportScript): update catalogue creation to include new fields and license handling The changes introduce new fields in the CatalogueDTOBase to enhance the data model, allowing for better representation of catalogues. The `fetchPreExistingLicence` function retrieves existing licenses, improving the import process by ensuring that licenses are correctly associated with catalogues. Additionally, the catalogue creation process is updated to include new fields and handle licenses more effectively, ensuring that all relevant data is captured during imports.