### PR TITLE
feat(keycloak): add legal notice and sponsor information to the configuration and login template

### DIFF
--- a/platform/web/packages/keycloak/src/config.ts
+++ b/platform/web/packages/keycloak/src/config.ts
@@ -4,9 +4,20 @@ export interface PlatformConfig {
 
 export interface Config {
     platform: PlatformConfig
+    legalNotice?: LegalNotice,
+    sponsor?: Sponsor,
     theme?: ThemeConfig
 }
 
+export interface LegalNotice {
+    url: string
+}
+export interface Sponsor {
+    logo: string
+    by: string
+    url: string
+    name: string
+}
 export interface ThemeConfig {
     colors?: ThemeColorsConfig,
     rotation?: string

--- a/platform/web/packages/keycloak/src/login/Template.tsx
+++ b/platform/web/packages/keycloak/src/login/Template.tsx
@@ -4,8 +4,9 @@ import { type TemplateProps } from "keycloakify/login/TemplateProps";
 import type { KcContext } from "./KcContext";
 import type { I18n } from "./i18n";
 import { CssBaseline, Paper, Stack, Typography, styled } from '@mui/material'
-import { Alert } from "@komune-io/g2"
+import {Alert, Link} from "@komune-io/g2"
 import { KeycloakLanguageSelector } from "./KeycloakLanguageSelector";
+import {config} from "../config.ts";
 
 const Main = styled('main')({
     flexGrow: 1,
@@ -22,9 +23,10 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
         headerNode,
         i18n,
     } = props;
-
+    const { msgStr } = i18n;
     const { currentLanguage, enabledLanguages } = i18n;
     const { message, isAppInitiatedAction, } = kcContext;
+    const { legalNotice, sponsor } = config()
 
     return (
         <Main
@@ -119,6 +121,55 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
                         {headerNode && <Typography sx={{ color: "primary.main", alignSelf: "center" }} align="center" variant="h4">{headerNode}</Typography>}
                         {children}
                     </Paper>
+                    {sponsor && (
+                        <>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    textAlign: 'center',
+                                    whiteSpace: 'nowrap',
+                                    gap: 0.5,
+                                }}
+                            >
+                                <img
+                                    alt="Sponsor Logo"
+                                    src={sponsor.logo}
+                                    style={{
+                                        height: "50px",
+                                        marginRight: "24px",
+                                    }}
+                                />
+                                {msgStr("sponsorProject")}
+                                <Link
+                                    variant="body2"
+                                    href={sponsor.url}
+                                    sx={{fontSize: "unset"}}
+                                >
+                                    {sponsor.name}
+                                </Link>
+                                {msgStr("sponsorSupportedBy", sponsor.by )}
+                            </Typography>
+
+                        </>
+
+                    )}
+                    {legalNotice && (
+                    <Link
+                        variant="body2"
+                        href={legalNotice.url}
+                        sx={{
+                            color: "#828282",
+                            textDecoration: "unset !important",
+                            mt: -1,
+                            alignSelf: "center"
+                        }}
+                    >
+                        {`${msgStr("legalNotice" )} `}
+                    </Link>
+                    )}
                 </Stack>
             </Stack>
         </Main >

--- a/platform/web/packages/keycloak/src/login/i18n.ts
+++ b/platform/web/packages/keycloak/src/login/i18n.ts
@@ -35,6 +35,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             and: "and",
             privacyPolicy: "privacy policy",
             charter: "the charter of 100 millions",
+            legalNotice: "Legal notice",
             loginTotpStep2: "Open the application and scan the following qr code",
             loginTotpStep3: "Enter the one-time code provided by the application and click Submit to finish the setup.",
             loginTotpManualStep2: "Open the application and enter the following key:",
@@ -42,7 +43,9 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             loginTotpStep3DeviceName: "Provide a Device Name to help you manage your OTP devices.",
             loginTotpScanBarcode: "Scan a qr code instead",
             loginOtpInfo: "Please enter the code provided by your authentication app.",
-            verifyIdentity: "Verify your identity"
+            verifyIdentity: "Verify your identity",
+            sponsorProject: 'The project',
+            sponsorSupportedBy: 'is supported by {3}.',
         },
         fr: {
             emailForgotTitle: "Réinitialisation de votre mot de passe ?",
@@ -73,6 +76,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             and: "et",
             privacyPolicy: "la politique de confidentialité",
             charter: "la charte des 100 millions",
+            legalNotice: "Mentions légales",
             loginTotpStep2: "Ouvrez l'application et scannez le qr code ci-dessous:",
             loginTotpStep3: "Entrez le code à usage unique fourni par l'application et cliquez sur Soumettre pour terminer.",
             loginTotpManualStep2: "Ouvrez l'application et saisissez la clé ci-dessous:",
@@ -80,7 +84,9 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             loginTotpStep3DeviceName: "Renseignez le nom de l'appareil pour vous aider à gérer vos appareils OTP.",
             loginTotpScanBarcode: "Scanner un qr code à la place",
             loginOtpInfo: "Veuillez saisir le code fourni par votre application d’authentification.",
-            verifyIdentity: "Vérifiez votre identité"
+            verifyIdentity: "Vérifiez votre identité",
+            sponsorProject: 'Le projet',
+            sponsorSupportedBy: 'est soutenu par {3}.',
         },
         es: {
             emailForgotTitle: "¿Restablecer la contraseña?",
@@ -111,6 +117,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             and: "y",
             privacyPolicy: "política de privacidad",
             charter: "la carta de 100 millones",
+            legalNotice: "Aviso legal",
             loginTotpStep2: "Abra la aplicación y escanee el siguiente código QR",
             loginTotpStep3: "Ingrese el código de un solo uso proporcionado por la aplicación y haga clic en Enviar para finalizar la configuración.",
             loginTotpManualStep2: "Abra la aplicación e ingrese la siguiente clave:",
@@ -118,7 +125,9 @@ const { useI18n, ofTypeI18n } = i18nBuilder
             loginTotpStep3DeviceName: "Proporcione un nombre de dispositivo para ayudarle a gestionar sus dispositivos OTP.",
             loginTotpScanBarcode: "Escanear un código QR en su lugar",
             loginOtpInfo: "Por favor, introduzca el código proporcionado por su aplicación de autenticación.",
-            verifyIdentity: "Verifique su identidad"
+            verifyIdentity: "Verifique su identidad",
+            sponsorProject: 'El proyecto',
+            sponsorSupportedBy: 'cuenta con el apoyo de {3}.',
         }
     })
     .build();

--- a/platform/web/packages/keycloak/src/main.tsx
+++ b/platform/web/packages/keycloak/src/main.tsx
@@ -15,7 +15,7 @@ G2ConfigBuilder(window._env_)
 
 if (import.meta.env.DEV) {
     window.kcContext = getKcContextMock({
-        pageId: "login-config-totp.ftl",
+        pageId: "login.ftl",
         overrides: {
             locale: {
                 currentLanguageTag: "fr"


### PR DESCRIPTION

The configuration now includes optional fields for legal notice and sponsor details. The login template displays this information if provided, enhancing user awareness and promoting sponsors. This change aims to improve transparency and support for the project.