### PR TITLE
fix(CatalogueMetadataForm.tsx): change required field from true to false for illustration input

### DIFF
--- a/platform/web/packages/100mComponents/src/CatalogueMetadataForm/CatalogueMetadataForm.tsx
+++ b/platform/web/packages/100mComponents/src/CatalogueMetadataForm/CatalogueMetadataForm.tsx
@@ -115,7 +115,7 @@ export const CatalogueMetadataForm = (props: CatalogueMetadataFormProps) => {
             multiline: true,
             rows: 7
         },
-        required: true
+        required: false
     }, {
         name: "illustration",
         type: "documentHandler",


### PR DESCRIPTION
The illustration input field is now marked as not required, allowing users to submit the form without providing an illustration. This change improves user experience by making the form more flexible and accommodating for users who may not have an illustration to upload.