### PR TITLE
chore(docker): comment out NPM_AUTH_TOKEN handling in Dockerfile for …

### DIFF
--- a/infra/docker/keycloak/Dockerfile
+++ b/infra/docker/keycloak/Dockerfile
@@ -11,11 +11,11 @@ RUN apk add --no-cache git=2.43.6-r0 && \
 
 COPY platform/web ./
 
-ARG NPM_AUTH_TOKEN
-RUN printf "\
-@komune-io:registry=https://npm.pkg.github.com\n\
-//npm.pkg.github.com/:_authToken=%s\n\
-" "${NPM_AUTH_TOKEN}" > .npmrc
+#ARG NPM_AUTH_TOKEN
+#RUN printf "\
+#@komune-io:registry=https://npm.pkg.github.com\n\
+#//npm.pkg.github.com/:_authToken=%s\n\
+#" "${NPM_AUTH_TOKEN}" > .npmrc
 
 ARG VERSION
 ENV REACT_APP_VERSION=$VERSION

--- a/infra/docker/ver-web-app/Dockerfile
+++ b/infra/docker/ver-web-app/Dockerfile
@@ -9,11 +9,11 @@ RUN apk add --no-cache git=2.47.2-r0 && \
     git init
 
 
-ARG NPM_AUTH_TOKEN
-RUN printf "\
-@komune-io:registry=https://npm.pkg.github.com\n\
-//npm.pkg.github.com/:_authToken=%s\n\
-" "${NPM_AUTH_TOKEN}" > .npmrc
+#ARG NPM_AUTH_TOKEN
+#RUN printf "\
+#@komune-io:registry=https://npm.pkg.github.com\n\
+#//npm.pkg.github.com/:_authToken=%s\n\
+#" "${NPM_AUTH_TOKEN}" > .npmrc
 
 ARG VERSION
 ENV VITE_APP_VERSION=$VERSION


### PR DESCRIPTION
…security reasons

The handling of the NPM_AUTH_TOKEN is commented out to prevent accidental exposure of sensitive information during the Docker build process. This change enhances security by ensuring that authentication tokens are not hardcoded or logged inadvertently.