### PR TITLE
Add catalogue history feature and update authentication client_id

### DIFF
--- a/infra/http/api.http
+++ b/infra/http/api.http
@@ -9,7 +9,7 @@
 POST {{urlAuth}}/protocol/openid-connect/token
 Content-Type: application/x-www-form-urlencoded
 
-client_id = tr-registry-script-api &
+client_id = tr-komune-import-api-key &
 client_secret = secret &
 grant_type = client_credentials
 
@@ -425,4 +425,13 @@ Authorization: Bearer {{accessToken}}
   "parentIdentifier": "100m",
   "offset": 0,
   "limit": 40
+}
+
+### cataloguePage
+POST {{urlBase}}/data/catalogueHistoryGet
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "id": "100m-solution-34"
 }

--- a/platform/commons/src/commonMain/kotlin/io/komune/registry/s2/commons/history/EventHistory.kt
+++ b/platform/commons/src/commonMain/kotlin/io/komune/registry/s2/commons/history/EventHistory.kt
@@ -1,0 +1,33 @@
+package io.komune.registry.s2.commons.history
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Data class representing an event with its index and corresponding entity state.
+ * @param indexEvent The index of the event in the sequence.
+ * @param event The event itself.
+ * @param model The entity state after applying the event.
+ */
+@Serializable
+data class EventHistory<EVENT, ENTITY>(
+    val indexEvent: Int,
+    val eventType: String,
+    val event: EVENT,
+    val model: ENTITY
+)
+
+
+fun <EVENT, ENTITY, RESULT> List<EventHistory<EVENT, ENTITY & Any>>.mapEntities(
+    transform: (EventHistory<EVENT, ENTITY & Any>) -> RESULT
+) =
+    map { eventHistory ->
+        eventHistory.mapEntity(transform)
+    }
+
+fun <EVENT, ENTITY, RESULT> EventHistory<EVENT, ENTITY & Any>.mapEntity(
+    transform: (EventHistory<EVENT, ENTITY & Any>) -> RESULT
+): EventHistory<EVENT, RESULT> {
+    val model = transform(this)
+
+    return EventHistory(this.indexEvent, this.eventType, this.event, model)
+}

--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/CatalogueEndpoint.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/CatalogueEndpoint.kt
@@ -59,8 +59,11 @@ import io.komune.registry.f2.catalogue.domain.query.CatalogueRefGetTreeFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueRefGetTreeResult
 import io.komune.registry.f2.catalogue.domain.query.CatalogueRefSearchFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueSearchFunction
+import io.komune.registry.f2.catalogue.domain.query.CatalogueHistoryGetFunction
+import io.komune.registry.f2.catalogue.domain.query.CatalogueHistoryGetResult
 import io.komune.registry.f2.organization.domain.model.OrganizationRef
 import io.komune.registry.program.s2.catalogue.api.CatalogueAggregateService
+import io.komune.registry.program.s2.catalogue.api.CatalogueEventWithStateService
 import io.komune.registry.program.s2.catalogue.api.CatalogueFinderService
 import io.komune.registry.s2.catalogue.domain.command.CatalogueUnlinkCataloguesCommand
 import io.komune.registry.s2.commons.model.CatalogueId
@@ -91,9 +94,20 @@ class CatalogueEndpoint(
     private val fileClient: FileClient,
     private val certificate: CatalogueCertificateService,
     private val catalogueSearchFinderService: CatalogueSearchFinderService,
+    private val catalogueEventWithStateService: CatalogueEventWithStateService,
 ): CatalogueApi {
 
     private val logger by Logger()
+
+    @Bean
+    override fun catalogueHistoryGet(): CatalogueHistoryGetFunction = f2Function { query ->
+        logger.info("catalogueHistoryGet: $query")
+        val history = catalogueEventWithStateService.getHistory(query.id)
+        cataloguePoliciesFilterEnforcer.checkHistory(history)
+        CatalogueHistoryGetResult(
+            history = history
+        )
+    }
 
     @Bean
     override fun cataloguePage(): CataloguePageFunction = f2Function { query ->

--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CataloguePoliciesEnforcer.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CataloguePoliciesEnforcer.kt
@@ -9,8 +9,11 @@ import io.komune.registry.f2.catalogue.domain.dto.CatalogueDraftRefDTOBase
 import io.komune.registry.f2.catalogue.draft.domain.CatalogueDraftPolicies
 import io.komune.registry.f2.dataset.api.model.toRef
 import io.komune.registry.f2.user.api.service.UserF2FinderService
+import io.komune.registry.s2.catalogue.domain.command.CatalogueEvent
+import io.komune.registry.s2.catalogue.domain.model.CatalogueModel
 import io.komune.registry.s2.catalogue.draft.api.CatalogueDraftFinderService
 import io.komune.registry.s2.commons.auth.Permissions
+import io.komune.registry.s2.commons.history.EventHistory
 import io.komune.registry.s2.commons.model.CatalogueDraftId
 import io.komune.registry.s2.commons.model.CatalogueId
 import org.springframework.stereotype.Service

--- a/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CataloguePoliciesFilterEnforcer.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-api/src/main/kotlin/io/komune/registry/f2/catalogue/api/service/CataloguePoliciesFilterEnforcer.kt
@@ -1,14 +1,17 @@
 package io.komune.registry.f2.catalogue.api.service
 
 import f2.dsl.cqrs.filter.ExactMatch
+import f2.spring.exception.ForbiddenAccessException
 import io.komune.im.commons.auth.hasRole
 import io.komune.im.commons.auth.policies.PolicyEnforcer
 import io.komune.registry.f2.catalogue.domain.CataloguePolicies
 import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTOBase
+import io.komune.registry.s2.catalogue.domain.command.CatalogueEvent
 import io.komune.registry.s2.catalogue.domain.model.CatalogueAccessRight
 import io.komune.registry.s2.catalogue.domain.model.CatalogueCriterionField
 import io.komune.registry.s2.catalogue.domain.model.CatalogueModel
 import io.komune.registry.s2.commons.auth.Permissions
+import io.komune.registry.s2.commons.history.EventHistory
 import io.komune.registry.s2.commons.model.Criterion
 import io.komune.registry.s2.commons.model.FieldCriterion
 import io.komune.registry.s2.commons.model.orCriterionOf
@@ -58,4 +61,9 @@ class CataloguePoliciesFilterEnforcer : PolicyEnforcer() {
             )
         }
     }
+
+    suspend fun checkHistory(history: List<EventHistory<CatalogueEvent, CatalogueModel>>) = checkAuthed("Get Catalogue history") { authedUser ->
+        history.none { enforceCatalogue(it.model) == null }
+    }
+
 }

--- a/platform/data/f2/catalogue-f2/catalogue-f2-client/src/commonMain/kotlin/io/komune/registry/f2/catalogue/client/CatalogueClient.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-client/src/commonMain/kotlin/io/komune/registry/f2/catalogue/client/CatalogueClient.kt
@@ -28,6 +28,7 @@ import io.komune.registry.f2.catalogue.domain.query.CatalogueRefGetFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueRefGetTreeFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueRefSearchFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueSearchFunction
+import io.komune.registry.f2.catalogue.domain.query.CatalogueHistoryGetFunction
 import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -79,6 +80,7 @@ open class CatalogueClient(val client: F2Client) : CatalogueApi {
         = client.function("data/${this::catalogueUnreferenceDatasets.name}")
     override fun catalogueLinkThemes(): CatalogueLinkThemesFunction = client.function("data/${this::catalogueLinkThemes.name}")
     override fun catalogueDelete(): CatalogueDeleteFunction = client.function("data/${this::catalogueDelete.name}")
+    override fun catalogueHistoryGet(): CatalogueHistoryGetFunction = client.function("data/${this::catalogueDelete.name}")
 
     override fun cataloguePage(): CataloguePageFunction = client.function("data/${this::cataloguePage.name}")
     override fun catalogueSearch(): CatalogueSearchFunction= client.function("data/${this::catalogueSearch.name}")

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/CatalogueQueryApi.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/CatalogueQueryApi.kt
@@ -1,5 +1,6 @@
 package io.komune.registry.f2.catalogue.domain
 
+import io.komune.registry.f2.catalogue.domain.query.CatalogueHistoryGetFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueGetByIdentifierFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueGetFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueListAllowedTypesFunction
@@ -13,6 +14,7 @@ import io.komune.registry.f2.catalogue.domain.query.CatalogueRefSearchFunction
 import io.komune.registry.f2.catalogue.domain.query.CatalogueSearchFunction
 
 interface CatalogueQueryApi {
+    fun catalogueHistoryGet(): CatalogueHistoryGetFunction
     fun cataloguePage(): CataloguePageFunction
     fun catalogueSearch(): CatalogueSearchFunction
     fun catalogueGet(): CatalogueGetFunction

--- a/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueGetHistoryDTO.kt
+++ b/platform/data/f2/catalogue-f2/catalogue-f2-domain/src/commonMain/kotlin/io/komune/registry/f2/catalogue/domain/query/CatalogueGetHistoryDTO.kt
@@ -1,0 +1,58 @@
+package io.komune.registry.f2.catalogue.domain.query
+
+import f2.dsl.fnc.F2Function
+import io.komune.registry.f2.catalogue.domain.dto.CatalogueDTOBase
+import io.komune.registry.s2.catalogue.domain.command.CatalogueEvent
+import io.komune.registry.s2.catalogue.domain.model.CatalogueModel
+import io.komune.registry.s2.commons.history.EventHistory
+import io.komune.registry.s2.commons.model.CatalogueId
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlinx.serialization.Serializable
+
+/**
+ * Get a catalogue by composite identifier.
+ * @d2 function
+ * @parent [io.komune.registry.f2.catalogue.domain.D2CatalogueF2Page]
+ * @order 11
+ */
+typealias CatalogueHistoryGetFunction = F2Function<CatalogueHistoryGetQuery, CatalogueHistoryGetResult>
+
+/**
+ * @d2 query
+ * @parent [CatalogueHistoryGetFunction]
+ */
+@JsExport
+@JsName("CatalogueHistoryGetQueryDTO")
+interface CatalogueHistoryGetQueryDTO {
+    /**
+     * Identifier of the catalogue to fetch.
+     */
+    val id: CatalogueId
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class CatalogueHistoryGetQuery(
+    override val id: CatalogueId
+): CatalogueHistoryGetQueryDTO
+
+/**
+ * @d2 event
+ * @parent [CatalogueHistoryGetFunction]
+ */
+@JsExport
+@JsName("CatalogueHistoryGetResultDTO")
+interface CatalogueHistoryGetResultDTO {
+    val history: List<EventHistory<CatalogueEvent, CatalogueModel>>
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class CatalogueHistoryGetResult(
+    override val history: List<EventHistory<CatalogueEvent, CatalogueModel>>
+): CatalogueHistoryGetResultDTO

--- a/platform/data/s2/catalogue/catalogue-api/build.gradle.kts
+++ b/platform/data/s2/catalogue/catalogue-api/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 	implementation(project(Modules.commons))
 	api(project(Modules.infra.meilisearch))
 	implementation(project(Modules.infra.postgresql))
-	implementation(project(Modules.infra.redis))
+	api(project(Modules.infra.redis))
 
 	implementation(project(Modules.api.config))
 

--- a/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/CatalogueEventWithStateService.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/CatalogueEventWithStateService.kt
@@ -1,0 +1,24 @@
+package io.komune.registry.program.s2.catalogue.api
+
+import io.komune.registry.infra.redis.EventHistoryService
+import io.komune.registry.program.s2.catalogue.api.config.CatalogueAutomateConfig
+import io.komune.registry.program.s2.catalogue.api.entity.CatalogueEntity
+import io.komune.registry.program.s2.catalogue.api.entity.toModel
+import io.komune.registry.s2.catalogue.domain.command.CatalogueEvent
+import io.komune.registry.s2.catalogue.domain.model.CatalogueModel
+import io.komune.registry.s2.commons.history.EventHistory
+import io.komune.registry.s2.commons.history.mapEntities
+import io.komune.registry.s2.commons.model.CatalogueId
+import org.springframework.stereotype.Service
+import s2.sourcing.dsl.event.EventRepository
+import s2.spring.sourcing.data.r2dbc.R2dbcEventRepository
+
+@Service
+class CatalogueEventWithStateService(
+    config: CatalogueAutomateConfig,
+    view: CatalogueEvolver
+): EventHistoryService<CatalogueEvent, CatalogueEntity, CatalogueId>(config.eventStore(), view) {
+    suspend fun getHistory(id: CatalogueId): List<EventHistory<CatalogueEvent, CatalogueModel>> {
+        return getEventsWithState(id).mapEntities { it.model.toModel() }
+    }
+}

--- a/platform/infra/redis/src/main/kotlin/io/komune/registry/infra/redis/EventHistoryService.kt
+++ b/platform/infra/redis/src/main/kotlin/io/komune/registry/infra/redis/EventHistoryService.kt
@@ -1,0 +1,44 @@
+package io.komune.registry.infra.redis
+
+import io.komune.registry.s2.commons.history.EventHistory
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import s2.dsl.automate.Evt
+import s2.dsl.automate.model.WithS2Id
+import s2.sourcing.dsl.event.EventRepository
+import s2.sourcing.dsl.view.View
+
+/**
+ * Service for retrieving events with their corresponding entity states.
+ * @param eventRepository Repository for retrieving events.
+ * @param view View for evolving entity state based on events.
+ */
+open class EventHistoryService<EVENT, ENTITY, ID>(
+    private val eventRepository: EventRepository<EVENT, ID>,
+    private val view: View<EVENT, ENTITY>
+) where EVENT : Evt, EVENT : WithS2Id<ID> {
+
+    /**
+     * Retrieves all events for the given object ID and constructs the entity state for each event.
+     * @param id The object ID.
+     * @return A list of EventWithState objects, each containing the event index, the event itself, and the entity state.
+     */
+    suspend fun getEventsWithState(id: ID): List<EventHistory<EVENT, ENTITY & Any>> {
+        val events = eventRepository.load(id)
+
+        var currentState: ENTITY? = null
+        var index = 0
+
+        return events.map { event ->
+            event::class.simpleName
+            index++
+            currentState = view.evolve(event, currentState)
+            EventHistory(
+                indexEvent = index,
+                event = event,
+                eventType = event::class.simpleName ?: "Unknown",
+                model = currentState!!
+            )
+        }.toList()
+    }
+}


### PR DESCRIPTION
Implements a new endpoint for fetching catalogue history with supporting components (CatalogueHistoryGetFunction, CatalogueEventWithStateService) and updates the client_id in API requests for proper authentication.