### PR TITLE
Improve event history sorting and clarify environment naming

### DIFF
--- a/infra/http/http-client.env.json
+++ b/infra/http/http-client.env.json
@@ -1,5 +1,5 @@
 {
-  "dev": {
+  "local": {
     "urlAuth": "http://im-keycloak:8080/realms/registry-local",
     "urlBase": "http://localhost:8070",
     "clientId": "registry-platform-app",

--- a/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/CatalogueEventWithStateService.kt
+++ b/platform/data/s2/catalogue/catalogue-api/src/main/kotlin/io/komune/registry/program/s2/catalogue/api/CatalogueEventWithStateService.kt
@@ -21,4 +21,13 @@ class CatalogueEventWithStateService(
     suspend fun getHistory(id: CatalogueId): List<EventHistory<CatalogueEvent, CatalogueModel>> {
         return getEventsWithState(id).mapEntities { it.model.toModel() }
     }
+
+    override fun <EVENT> sortBy(): Comparator<EVENT> = object : Comparator<EVENT> {
+        override fun compare(event1: EVENT, event2: EVENT): Int {
+            if (event1 is CatalogueEvent && event2 is CatalogueEvent) {
+                return event1.date.compareTo(event2.date)
+            }
+            return 0
+        }
+    }
 }


### PR DESCRIPTION
Refactors event history services to implement proper time-based sorting functionality and renames development environment from "dev" to "local" for better clarity in configuration files.