### PR TITLE
Add catalogueRefSearch endpoint and fix duplicate history replay

### DIFF
--- a/infra/http/api.http
+++ b/infra/http/api.http
@@ -427,6 +427,18 @@ Authorization: Bearer {{accessToken}}
   "limit": 40
 }
 
+### catalogueRefSearch
+POST {{urlBase}}/data/catalogueRefSearch
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "language":"es",
+  "type":["100m-planetary-boundary"],
+  "limit":10,
+  "offset":0
+}
+
 ### cataloguePage
 POST {{urlBase}}/data/catalogueHistoryGet
 Content-Type: application/json

--- a/platform/infra/redis/src/main/kotlin/io/komune/registry/infra/redis/RegistryS2SourcingSpringDataAdapter.kt
+++ b/platform/infra/redis/src/main/kotlin/io/komune/registry/infra/redis/RegistryS2SourcingSpringDataAdapter.kt
@@ -60,6 +60,7 @@ EXECUTOR : S2AutomateDeciderSpring<ENTITY, STATE, EVENT, ID>
 					logger.info("/////////////////////////")
 					logger.info("Replay ${entityType.name} history")
 					executor.replayHistory()
+					executor.replayHistory()
 					logger.info("/////////////////////////")
 				}
 			} catch (e: Exception) {


### PR DESCRIPTION
Adds a new API endpoint for searching catalogue references with specific parameters and removes a duplicate history replay call in the registry adapter for cleaner, more efficient code execution.